### PR TITLE
[revision] for {070a29e0ada556e07e6754132dc9ae85ef72bb8e}

### DIFF
--- a/arch/x86/realmode/rm/trampoline_64.S
+++ b/arch/x86/realmode/rm/trampoline_64.S
@@ -112,9 +112,9 @@ ENTRY(sl_trampoline_start32)
 	/*
 	 * This may seem a little odd but this is what %esp would have had in
 	 * it on the jmp from real mode because all real mode fixups were done
-	 * via the code segment.
+	 * via the code segment. The base is added at the 32b entry.
 	 */
-	leal	rm_stack_end(%ebx), %esp
+	movl	rm_stack_end, %esp
 
 	lgdt    tr_gdt(%ebx)
 	lidt    tr_idt(%ebx)


### PR DESCRIPTION
The %esp register should just have the image offset value for the stack in
it. The 32b entry code will add the actual image base offset later.
    
Signed-off-by: Ross Philipson <ross.philipson@oracle.com>