### PR TITLE
Move Secure Launch header and remove ifdefs

### DIFF
--- a/arch/x86/boot/compressed/sl_main.c
+++ b/arch/x86/boot/compressed/sl_main.c
@@ -16,7 +16,7 @@
 #include <asm/tpm.h>
 #include <asm/bootparam.h>
 #include <asm/efi.h>
-#include <asm/slaunch.h>
+#include <linux/slaunch.h>
 
 extern u32 sl_cpu_type;
 

--- a/arch/x86/boot/compressed/sl_stub.S
+++ b/arch/x86/boot/compressed/sl_stub.S
@@ -12,7 +12,7 @@
 #include <asm/asm-offsets.h>
 #include <asm/bootparam.h>
 #include <asm/irq_vectors.h>
-#include <asm/slaunch.h>
+#include <linux/slaunch.h>
 
 /* Can't include apiddef.h in asm */
 #define APIC_BASE_MSR	0x800

--- a/arch/x86/kernel/asm-offsets.c
+++ b/arch/x86/kernel/asm-offsets.c
@@ -12,13 +12,13 @@
 #include <linux/hardirq.h>
 #include <linux/suspend.h>
 #include <linux/kbuild.h>
+#include <linux/slaunch.h>
 #include <asm/processor.h>
 #include <asm/thread_info.h>
 #include <asm/sigframe.h>
 #include <asm/bootparam.h>
 #include <asm/suspend.h>
 #include <asm/tlbflush.h>
-#include <asm/slaunch.h>
 
 #ifdef CONFIG_XEN
 #include <xen/interface/xen.h>

--- a/arch/x86/kernel/setup.c
+++ b/arch/x86/kernel/setup.c
@@ -71,6 +71,7 @@
 #include <linux/tboot.h>
 #include <linux/jiffies.h>
 #include <linux/mem_encrypt.h>
+#include <linux/slaunch.h>
 
 #include <linux/usb/xhci-dbgp.h>
 #include <video/edid.h>
@@ -117,7 +118,6 @@
 #include <asm/microcode.h>
 #include <asm/kaslr.h>
 #include <asm/unwind.h>
-#include <asm/slaunch.h>
 
 /*
  * max_low_pfn_mapped: highest direct mapped pfn under 4GB
@@ -1038,9 +1038,7 @@ void __init setup_arch(char **cmdline_p)
 	early_gart_iommu_check();
 #endif
 
-#ifdef CONFIG_SECURE_LAUNCH
 	slaunch_setup();
-#endif
 
 	/*
 	 * partially used pages are not usable - thus

--- a/arch/x86/kernel/slaunch.c
+++ b/arch/x86/kernel/slaunch.c
@@ -25,7 +25,7 @@
 #include <asm/e820/api.h>
 #include <asm/bootparam.h>
 #include <asm/setup.h>
-#include <asm/slaunch.h>
+#include <linux/slaunch.h>
 
 #define PREFIX	"SLAUNCH: "
 

--- a/arch/x86/realmode/rm/trampoline_64.S
+++ b/arch/x86/realmode/rm/trampoline_64.S
@@ -32,7 +32,6 @@
 #include <asm/segment.h>
 #include <asm/processor-flags.h>
 #include <asm/realmode.h>
-#include <asm/slaunch.h>
 #include "realmode.h"
 
 	.text

--- a/drivers/iommu/dmar.c
+++ b/drivers/iommu/dmar.c
@@ -40,9 +40,9 @@
 #include <linux/slab.h>
 #include <linux/iommu.h>
 #include <linux/numa.h>
+#include <linux/slaunch.h>
 #include <asm/irq_remapping.h>
 #include <asm/iommu_table.h>
-#include <asm/slaunch.h>
 
 #include "irq_remapping.h"
 
@@ -634,11 +634,10 @@ parse_dmar_table(void)
 	 * ACPI tables may not be DMA protected by tboot, so use DMAR copy
 	 * SINIT saved in SinitMleData in TXT heap (which is DMA protected)
 	 */
-#ifdef CONFIG_SECURE_LAUNCH
-	dmar_tbl = slaunch_get_dmar_table(dmar_tbl);
-#else
 	dmar_tbl = tboot_get_dmar_table(dmar_tbl);
-#endif
+
+	/* If Secure Launch is active, it has similar logic */
+	dmar_tbl = slaunch_get_dmar_table(dmar_tbl);
 
 	dmar = (struct acpi_table_dmar *)dmar_tbl;
 	if (!dmar)

--- a/include/linux/slaunch.h
+++ b/include/linux/slaunch.h
@@ -1,6 +1,15 @@
 /* SPDX-License-Identifier: GPL-2.0 */
-#ifndef _ASM_X86_SLAUNCH_H
-#define _ASM_X86_SLAUNCH_H
+#ifndef _LINUX_SLAUNCH_H
+#define _LINUX_SLAUNCH_H
+
+/*
+ * Secure Launch Defined State Flags
+ */
+#define SL_FLAG_ACTIVE		0x00000001
+#define SL_FLAG_ARCH_SKINIT	0x00000002
+#define SL_FLAG_ARCH_TXT	0x00000004
+
+#ifdef CONFIG_SECURE_LAUNCH
 
 /*
  * Secure Launch main definitions file.
@@ -165,13 +174,6 @@
 #define SL_IMAGE_PCR17		17
 #define SL_CONFIG_PCR18		18
 
-/*
- * Secure Launch Defined Flags
- */
-#define SL_FLAG_ACTIVE		0x00000001
-#define SL_FLAG_ARCH_SKINIT	0x00000002
-#define SL_FLAG_ARCH_TXT	0x00000004
-
 #ifndef __ASSEMBLY__
 
 /*
@@ -295,5 +297,14 @@ u32 slaunch_get_ap_wake_block(void);
 struct acpi_table_header *slaunch_get_dmar_table(struct acpi_table_header *dmar);
 
 #endif
+
+#else
+
+#define slaunch_setup()			do { } while (0)
+#define slaunch_get_flags()		0
+#define slaunch_get_dmar_table(d)	(d)
+#define slaunch_sexit()			do { } while (0)
+
+#endif /* !CONFIG_SECURE_LAUNCH */
 
 #endif /* _ASM_X86_SLAUNCH_H */


### PR DESCRIPTION
Since the slaunch.h file is not used outside of arch/x86 it has to move to include/linux. Also reduce the number of ifdefs for Secure Launch in the code by using stub definitions for functions.