### PR TITLE
Create an MLE scratch area in the heap for MLE use

### DIFF
--- a/arch/x86/boot/compressed/sl_main.c
+++ b/arch/x86/boot/compressed/sl_main.c
@@ -301,6 +301,7 @@ void sl_main(u8 *bootparams)
 	u64 bios_data_size;
 	u32 data_count;
 	u32 os_mle_len;
+	u64 scratch;
 
 	/*
 	 * Currently only Intel TXT is supported for Secure Launch. Testing this value
@@ -383,15 +384,18 @@ void sl_main(u8 *bootparams)
 			((u8 *)txt_heap + bios_data_size + sizeof(u64));
 
 	/*
-	 * Don't want to measure the value of the ap_wake_ebp field,
-	 * it only used by sl_stub
+	 * Don't want to measure the value of the mle_scratch field,
+	 * it only used internally by the MLE kernel.
 	 */
-	os_mle_data->ap_wake_ebp = 0;
+	scratch = os_mle_data->mle_scratch;
+	os_mle_data->mle_scratch = 0;
 
 	/* Measure OS-MLE data up to the TPM log into 18 */
 	os_mle_len = offsetof(struct txt_os_mle_data, event_log_buffer);
 	sl_tpm_extend_pcr(tpm, SL_CONFIG_PCR18, (u8 *)os_mle_data, os_mle_len,
 			  "Measured TXT OS-MLE data into PCR18");
+
+	os_mle_data->mle_scratch = scratch;
 
 	/*
 	 * Now that the OS-MLE data is measured, ensure the MTRR and

--- a/arch/x86/boot/compressed/sl_stub.S
+++ b/arch/x86/boot/compressed/sl_stub.S
@@ -129,11 +129,14 @@ ENTRY(sl_stub)
 	movl	SL_zero_page_addr(%eax), %esi
 
 	/* Save ebp so the APs can find their way home */
-	movl	%ebp, SL_ap_wake_ebp(%eax)
+	movl	%ebp, (SL_mle_scratch + SL_MLE_SCRATCH_AP_EBP)(%eax)
 
 	/* Fetch the AP wake code block address from the heap */
 	movl	SL_ap_wake_block(%eax), %edi
 	movl	%edi, sl_txt_ap_wake_block(%ebp)
+
+	/* Store the offset in the AP wake block to the jmp address */
+	movl	$(sl_ap_jmp_offset - sl_txt_ap_wake), (SL_mle_scratch + SL_MLE_SCRATCH_AP_JMP_OFFSET)(%eax)
 
 	/* %eax still is the base of the OS-MLE block, save it */
 	pushl	%eax
@@ -196,7 +199,7 @@ ENTRY(sl_txt_ap_entry)
 	leal	8(%eax, %ecx), %eax
 
 	/* Saved ebp from the BSP and stash OS-MLE pointer */
-	movl	SL_ap_wake_ebp(%eax), %ebp
+	movl	(SL_mle_scratch + SL_MLE_SCRATCH_AP_EBP)(%eax), %ebp
 	movl	%eax, %edi
 
 	/* Lock and get our stack index */
@@ -460,6 +463,7 @@ ENTRY(sl_txt_ap_wake)
 	 * is provided and protected in the memory map by the prelaunch code.
 	 */
 	.byte	0xea
+sl_ap_jmp_offset:
 	.long	0x00000000
 	.word	__SL32_CS
 ENDPROC(sl_txt_ap_wake)

--- a/arch/x86/kernel/asm-offsets.c
+++ b/arch/x86/kernel/asm-offsets.c
@@ -112,7 +112,7 @@ static void __used common(void)
 	OFFSET(SL_zero_page_addr, txt_os_mle_data, zero_page_addr);
 	OFFSET(SL_saved_misc_enable_msr, txt_os_mle_data, saved_misc_enable_msr);
 	OFFSET(SL_saved_bsp_mtrrs, txt_os_mle_data, saved_bsp_mtrrs);
-	OFFSET(SL_ap_wake_ebp, txt_os_mle_data, ap_wake_ebp);
+	OFFSET(SL_mle_scratch, txt_os_mle_data, mle_scratch);
 	OFFSET(SL_ap_wake_block, txt_os_mle_data, ap_wake_block);
 	OFFSET(SL_ap_gdt_base, txt_mle_join, ap_gdt_base);
 	OFFSET(SL_ap_entry_point, txt_mle_join, ap_entry_point);

--- a/include/linux/slaunch.h
+++ b/include/linux/slaunch.h
@@ -180,7 +180,21 @@
 #define SL_IMAGE_PCR17		17
 #define SL_CONFIG_PCR18		18
 
+/*
+ * MLE scratch area offsets
+ */
+#define SL_MLE_SCRATCH_AP_EBP		0
+#define SL_MLE_SCRATCH_AP_JMP_OFFSET	4
+
 #ifndef __ASSEMBLY__
+
+/*
+ * Secure Launch AP wakeup information fetched in SMP boot code.
+ */
+struct sl_ap_wake_info {
+	u64 ap_wake_block;
+	u32 ap_jmp_offset;
+};
 
 /*
  * TXT data structure used by a responsive local processor (RLP) to start
@@ -245,7 +259,7 @@ struct txt_os_mle_data {
 	u8	msb_key_hash[20];
 	u64	saved_misc_enable_msr;
 	struct	txt_mtrr_state saved_bsp_mtrrs;
-	u64	ap_wake_ebp;
+	u64	mle_scratch;
 	u64	ap_wake_block;
 	u8	event_log_buffer[TXT_MAX_EVENT_LOG_SIZE];
 } __packed;
@@ -472,7 +486,7 @@ static inline int tpm20_log_event(struct txt_heap_event_log_pointer2_1_element *
  */
 void slaunch_setup(void);
 u32 slaunch_get_flags(void);
-u32 slaunch_get_ap_wake_block(void);
+struct sl_ap_wake_info *slaunch_get_ap_wake_info(void);
 struct acpi_table_header *slaunch_get_dmar_table(struct acpi_table_header *dmar);
 void slaunch_sexit(void);
 


### PR DESCRIPTION
This scratch space is used to:
 - Hold the %ebp base pointer for use on APs at startup.
 - Hold the jmp offset in the relocated AP wake block used in SMP startup.