### PR TITLE
Fix migration issues

### DIFF
--- a/arch/x86/boot/compressed/early_sha256.c
+++ b/arch/x86/boot/compressed/early_sha256.c
@@ -3,4 +3,4 @@
  * Copyright (c) 2019 Apertus Solutions, LLC
  */
 
-#include "../../../../lib/sha256.c"
+#include "../../../../lib/crypto/sha256.c"

--- a/arch/x86/boot/compressed/sl_main.c
+++ b/arch/x86/boot/compressed/sl_main.c
@@ -17,7 +17,7 @@
 #include <asm/efi.h>
 #include <linux/slaunch.h>
 #ifdef CONFIG_SECURE_LAUNCH_SHA256
-#include <linux/sha256.h>
+#include <config/crypto/sha256.h>
 #endif
 #ifdef CONFIG_SECURE_LAUNCH_SHA512
 #include <linux/sha512.h>

--- a/arch/x86/realmode/rm/trampoline_64.S
+++ b/arch/x86/realmode/rm/trampoline_64.S
@@ -102,9 +102,6 @@ ENTRY(sl_trampoline_start32)
 	 */
 	movl    $pa_real_mode_base, %ebx
 
-	movl	$0xA5A5A5A5, trampoline_status(%ebx)
-	# write marker for master knows we're running
-
 	/*
 	 * This may seem a little odd but this is what %esp would have had in
 	 * it on the jmp from real mode because all real mode fixups were done


### PR DESCRIPTION
 - The trampoline_status field disappeared from the rmpiggy code in 5.4
 - The sha256 files moved around
What ever caused sha256 files to move around should be imitated when we add the sha512 files.