### PR TITLE
Cleanup of main SL header from v2 internal review

### DIFF
--- a/arch/x86/boot/compressed/sl_stub.S
+++ b/arch/x86/boot/compressed/sl_stub.S
@@ -110,12 +110,12 @@ ENTRY(sl_stub)
 
 .Lnmi_enabled:
 	/* Clear the TXT error registers for a clean start of day */
-	movl	$0, (TXT_PRIV_CONFIG_REGS_BASE + TXTCR_ERRORCODE)
-	movl	$0xffffffff, (TXT_PRIV_CONFIG_REGS_BASE + TXTCR_ESTS)
+	movl	$0, (TXT_PRIV_CONFIG_REGS_BASE + TXT_CR_ERRORCODE)
+	movl	$0xffffffff, (TXT_PRIV_CONFIG_REGS_BASE + TXT_CR_ESTS)
 
 	/* On Intel, the zero page address is passed in the TXT heap */
 	/* Read physical base of heap into EAX */
-	movl	(TXT_PRIV_CONFIG_REGS_BASE + TXTCR_HEAP_BASE), %eax
+	movl	(TXT_PRIV_CONFIG_REGS_BASE + TXT_CR_HEAP_BASE), %eax
 	/* Read the size of the BIOS data into ECX (in first 8 bytes */
 	movl	(%eax), %ecx
 	/* Skip over BIOS data and size of OS to MLE */
@@ -129,14 +129,14 @@ ENTRY(sl_stub)
 	movl	SL_zero_page_addr(%eax), %esi
 
 	/* Save ebp so the APs can find their way home */
-	movl	%ebp, (SL_mle_scratch + SL_MLE_SCRATCH_AP_EBP)(%eax)
+	movl	%ebp, (SL_mle_scratch + SL_SCRATCH_AP_EBP)(%eax)
 
 	/* Fetch the AP wake code block address from the heap */
 	movl	SL_ap_wake_block(%eax), %edi
 	movl	%edi, sl_txt_ap_wake_block(%ebp)
 
 	/* Store the offset in the AP wake block to the jmp address */
-	movl	$(sl_ap_jmp_offset - sl_txt_ap_wake), (SL_mle_scratch + SL_MLE_SCRATCH_AP_JMP_OFFSET)(%eax)
+	movl	$(sl_ap_jmp_offset - sl_txt_ap_wake), (SL_mle_scratch + SL_SCRATCH_AP_JMP_OFFSET)(%eax)
 
 	/* %eax still is the base of the OS-MLE block, save it */
 	pushl	%eax
@@ -192,14 +192,14 @@ ENTRY(sl_txt_ap_entry)
 	 */
 
 	/* Read physical base of heap into EAX */
-	movl	(TXT_PRIV_CONFIG_REGS_BASE + TXTCR_HEAP_BASE), %eax
+	movl	(TXT_PRIV_CONFIG_REGS_BASE + TXT_CR_HEAP_BASE), %eax
 	/* Read the size of the BIOS data into ECX (in first 8 bytes */
 	movl	(%eax), %ecx
 	/* Skip over BIOS data and size of OS to MLE */
 	leal	8(%eax, %ecx), %eax
 
 	/* Saved ebp from the BSP and stash OS-MLE pointer */
-	movl	(SL_mle_scratch + SL_MLE_SCRATCH_AP_EBP)(%eax), %ebp
+	movl	(SL_mle_scratch + SL_SCRATCH_AP_EBP)(%eax), %ebp
 	movl	%eax, %edi
 
 	/* Lock and get our stack index */
@@ -395,10 +395,10 @@ ENTRY(sl_txt_wake_aps)
 	leal	sl_smx_rlp_mle_join(%ebp), %edx
 	movl	%eax, SL_rlp_gdt_base(%edx)
 	movl	%ecx, SL_rlp_entry_point(%edx)
-	movl	%edx, (TXT_PRIV_CONFIG_REGS_BASE + TXTCR_MLE_JOIN)
+	movl	%edx, (TXT_PRIV_CONFIG_REGS_BASE + TXT_CR_MLE_JOIN)
 
 	/* Another TXT heap walk to find various values needed to wake APs */
-	movl	(TXT_PRIV_CONFIG_REGS_BASE + TXTCR_HEAP_BASE), %eax
+	movl	(TXT_PRIV_CONFIG_REGS_BASE + TXT_CR_HEAP_BASE), %eax
 	/* At BIOS data size, find the number of logical processors */
 	movl	(SL_num_logical_procs + 8)(%eax), %edx
 	/* Skip over BIOS data */
@@ -476,11 +476,11 @@ ENTRY(sl_txt_int_ipi_wake)
 ENDPROC(sl_txt_int_ipi_wake)
 
 ENTRY(sl_txt_int_reset)
-	movl	$(TXT_SLERROR_INV_AP_INTERRUPT), (TXT_PRIV_CONFIG_REGS_BASE + TXTCR_ERRORCODE)
-	movl	(TXT_PRIV_CONFIG_REGS_BASE + TXTCR_E2STS), %eax
-	movl	$1, (TXT_PRIV_CONFIG_REGS_BASE + TXTCR_CMD_UNLOCK_MEM_CONFIG)
-	movl	(TXT_PRIV_CONFIG_REGS_BASE + TXTCR_E2STS), %eax
-	movl	$1, (TXT_PRIV_CONFIG_REGS_BASE + TXTCR_CMD_RESET)
+	movl	$(SL_ERROR_INV_AP_INTERRUPT), (TXT_PRIV_CONFIG_REGS_BASE + TXT_CR_ERRORCODE)
+	movl	(TXT_PRIV_CONFIG_REGS_BASE + TXT_CR_E2STS), %eax
+	movl	$1, (TXT_PRIV_CONFIG_REGS_BASE + TXT_CR_CMD_UNLOCK_MEM_CONFIG)
+	movl	(TXT_PRIV_CONFIG_REGS_BASE + TXT_CR_E2STS), %eax
+	movl	$1, (TXT_PRIV_CONFIG_REGS_BASE + TXT_CR_CMD_RESET)
 1:
 	pause
 	jmp 	1b

--- a/arch/x86/kernel/slaunch.c
+++ b/arch/x86/kernel/slaunch.c
@@ -656,16 +656,16 @@ void slaunch_sexit(void)
 	}
 
 	/* Clear secrets bit for SEXIT */
-	memcpy_toio(config + TXTCR_CMD_NO_SECRETS, &one, sizeof(u64));
-	memcpy_fromio(&val, config + TXTCR_E2STS, sizeof(u64));
+	memcpy_toio(config + TXT_CR_CMD_NO_SECRETS, &one, sizeof(u64));
+	memcpy_fromio(&val, config + TXT_CR_E2STS, sizeof(u64));
 
 	/* Unlock memory configurations */
-	memcpy_toio(config + TXTCR_CMD_UNLOCK_MEM_CONFIG, &one, sizeof(u64));
-	memcpy_fromio(&val, config + TXTCR_E2STS, sizeof(u64));
+	memcpy_toio(config + TXT_CR_CMD_UNLOCK_MEM_CONFIG, &one, sizeof(u64));
+	memcpy_fromio(&val, config + TXT_CR_E2STS, sizeof(u64));
 
 	/* Close the TXT private register space */
-	memcpy_fromio(&val, config + TXTCR_E2STS, sizeof(u64));
-	memcpy_toio(config + TXTCR_CMD_CLOSE_PRIVATE, &one, sizeof(u64));
+	memcpy_fromio(&val, config + TXT_CR_E2STS, sizeof(u64));
+	memcpy_toio(config + TXT_CR_CMD_CLOSE_PRIVATE, &one, sizeof(u64));
 
 	/*
 	 * Calls to iounmap are not being done because of the state of the
@@ -683,7 +683,7 @@ void slaunch_sexit(void)
 		return;
 	}
 
-	memcpy_fromio(&val, config + TXTCR_E2STS, sizeof(u64));
+	memcpy_fromio(&val, config + TXT_CR_E2STS, sizeof(u64));
 
 	/* Disable SMX mode */
 	cr4_set_bits(X86_CR4_SMXE);

--- a/arch/x86/kernel/slaunch.c
+++ b/arch/x86/kernel/slaunch.c
@@ -574,8 +574,8 @@ static void slaunch_intel_evtlog(void)
 		return;
 	}
 
-	memcpy_fromio(&base, config + TXTCR_HEAP_BASE, sizeof(u64));
-	memcpy_fromio(&size, config + TXTCR_HEAP_SIZE, sizeof(u64));
+	memcpy_fromio(&base, config + TXT_CR_HEAP_BASE, sizeof(u64));
+	memcpy_fromio(&size, config + TXT_CR_HEAP_SIZE, sizeof(u64));
 	iounmap(config);
 
 	/* now map TXT heap */

--- a/include/linux/slaunch.h
+++ b/include/linux/slaunch.h
@@ -60,25 +60,25 @@
 /*
  * Intel Trusted Execution Technology (TXT) Registers
  */
-#define TXTCR_STS			0x0000
-#define TXTCR_ESTS			0x0008
-#define TXTCR_ERRORCODE			0x0030
-#define TXTCR_CMD_RESET			0x0038
-#define TXTCR_CMD_CLOSE_PRIVATE		0x0048
-#define TXTCR_DIDVID			0x0110
-#define TXTCR_CMD_UNLOCK_MEM_CONFIG	0x0218
-#define TXTCR_SINIT_BASE		0x0270
-#define TXTCR_SINIT_SIZE		0x0278
-#define TXTCR_MLE_JOIN			0x0290
-#define TXTCR_HEAP_BASE			0x0300
-#define TXTCR_HEAP_SIZE			0x0308
-#define TXTCR_CMD_OPEN_LOCALITY1	0x0380
-#define TXTCR_CMD_CLOSE_LOCALITY1	0x0388
-#define TXTCR_CMD_OPEN_LOCALITY2	0x0390
-#define TXTCR_CMD_CLOSE_LOCALITY2	0x0398
-#define TXTCR_CMD_SECRETS		0x08e0
-#define TXTCR_CMD_NO_SECRETS		0x08e8
-#define TXTCR_E2STS			0x08f0
+#define TXT_CR_STS			0x0000
+#define TXT_CR_ESTS			0x0008
+#define TXT_CR_ERRORCODE		0x0030
+#define TXT_CR_CMD_RESET		0x0038
+#define TXT_CR_CMD_CLOSE_PRIVATE	0x0048
+#define TXT_CR_DIDVID			0x0110
+#define TXT_CR_CMD_UNLOCK_MEM_CONFIG	0x0218
+#define TXT_CR_SINIT_BASE		0x0270
+#define TXT_CR_SINIT_SIZE		0x0278
+#define TXT_CR_MLE_JOIN			0x0290
+#define TXT_CR_HEAP_BASE		0x0300
+#define TXT_CR_HEAP_SIZE		0x0308
+#define TXT_CR_CMD_OPEN_LOCALITY1	0x0380
+#define TXT_CR_CMD_CLOSE_LOCALITY1	0x0388
+#define TXT_CR_CMD_OPEN_LOCALITY2	0x0390
+#define TXT_CR_CMD_CLOSE_LOCALITY2	0x0398
+#define TXT_CR_CMD_SECRETS		0x08e0
+#define TXT_CR_CMD_NO_SECRETS		0x08e8
+#define TXT_CR_E2STS			0x08f0
 
 /* TXTCR_STS status bits */
 #define TXT_SENTER_DONE_STS		(1<<0)
@@ -106,43 +106,41 @@
 #define TXT_SINIT_MLE_DATA_TABLE	4
 
 /*
- * Secure Launch Defined Error Codes
- * Used in MLE-initiated TXT resets
+ * Secure Launch Defined Error Codes used in MLE-initiated TXT resets.
+ *
+ * TXT Specification
+ * Appendix I ACM Error Codes
  */
-#define TXT_SLERROR_GENERIC		0xc0008001
-#define TXT_SLERROR_TPM_INIT		0xc0008002
-#define TXT_SLERROR_TPM_GET_LOC		0xc0008003
-#define TXT_SLERROR_TPM_EXTEND		0xc0008004
-#define TXT_SLERROR_MTRR_INV_VCNT	0xc0008005
-#define TXT_SLERROR_MTRR_INV_DEF_TYPE	0xc0008006
-#define TXT_SLERROR_MTRR_INV_BASE	0xc0008007
-#define TXT_SLERROR_MTRR_INV_MASK	0xc0008008
-#define TXT_SLERROR_MSR_INV_MISC_EN	0xc0008009
-#define TXT_SLERROR_INV_AP_INTERRUPT	0xc000800a
-#define TXT_SLERROR_RESERVE_AP_WAKE	0xc000800b
-#define TXT_SLERROR_HEAP_WALK		0xc000800c
-#define TXT_SLERROR_HEAP_MAP		0xc000800d
-#define TXT_SLERROR_HEAP_MDR_VALS	0xc000800e
-#define TXT_SLERROR_UNUSED1		0xc000800f
-#define TXT_SLERROR_UNUSED3		0xc0008010
-#define TXT_SLERROR_HEAP_INVALID_DMAR	0xc0008011
-#define TXT_SLERROR_HEAP_DMAR_SIZE	0xc0008012
-#define TXT_SLERROR_HEAP_DMAR_MAP	0xc0008013
-#define TXT_SLERROR_UNUSED2		0xc0008014
-#define TXT_SLERROR_HI_PMR_BASE		0xc0008015
-#define TXT_SLERROR_HI_PMR_SIZE		0xc0008016
-#define TXT_SLERROR_LO_PMR_BASE		0xc0008017
-#define TXT_SLERROR_LO_PMR_MLE		0xc0008018
-#define TXT_SLERROR_HEAP_ZERO_OFFSET	0xc0008019
-#define TXT_SLERROR_UNUSED4		0xc000801a
-#define TXT_SLERROR_TPM_INVALID_LOG20	0xc000801b
-#define TXT_SLERROR_TPM_LOGGING_FAILED	0xc000801c
+#define SL_ERROR_GENERIC		0xc0008001
+#define SL_ERROR_TPM_INIT		0xc0008002
+#define SL_ERROR_TPM_INVALID_LOG20	0xc0008003
+#define SL_ERROR_TPM_LOGGING_FAILED	0xc0008004
+#define SL_ERROR_TPM_GET_LOC		0xc0008005
+#define SL_ERROR_TPM_EXTEND		0xc0008006
+#define SL_ERROR_MTRR_INV_VCNT		0xc0008007
+#define SL_ERROR_MTRR_INV_DEF_TYPE	0xc0008008
+#define SL_ERROR_MTRR_INV_BASE		0xc0008009
+#define SL_ERROR_MTRR_INV_MASK		0xc000800a
+#define SL_ERROR_MSR_INV_MISC_EN	0xc000800b
+#define SL_ERROR_INV_AP_INTERRUPT	0xc000800c
+#define SL_ERROR_RESERVE_AP_WAKE	0xc000800d
+#define SL_ERROR_HEAP_WALK		0xc000800e
+#define SL_ERROR_HEAP_MAP		0xc000800f
+#define SL_ERROR_HEAP_MDR_VALS		0xc0008010
+#define SL_ERROR_HEAP_INVALID_DMAR	0xc0008011
+#define SL_ERROR_HEAP_DMAR_SIZE		0xc0008012
+#define SL_ERROR_HEAP_DMAR_MAP		0xc0008013
+#define SL_ERROR_HI_PMR_BASE		0xc0008014
+#define SL_ERROR_HI_PMR_SIZE		0xc0008015
+#define SL_ERROR_LO_PMR_BASE		0xc0008016
+#define SL_ERROR_LO_PMR_MLE		0xc0008017
+#define SL_ERROR_HEAP_ZERO_OFFSET	0xc0008018
 
 /*
  * Secure Launch Defined Limits
  */
-#define TXT_MAX_CPUS			512
-#define TXT_BOOT_STACK_SIZE		24
+#define TXT_MAX_CPUS		512
+#define TXT_BOOT_STACK_SIZE	24
 
 /*
  * Secure Launch event log entry type. The TXT specification defines the
@@ -160,8 +158,8 @@
 /*
  * MLE scratch area offsets
  */
-#define SL_MLE_SCRATCH_AP_EBP		0
-#define SL_MLE_SCRATCH_AP_JMP_OFFSET	4
+#define SL_SCRATCH_AP_EBP		0
+#define SL_SCRATCH_AP_JMP_OFFSET	4
 
 #ifndef __ASSEMBLY__
 
@@ -495,11 +493,11 @@ static inline int tpm20_log_event(struct txt_heap_event_log_pointer2_1_element *
 /*
  * External functions
  */
-void slaunch_setup(void);
-u32 slaunch_get_flags(void);
-struct sl_ap_wake_info *slaunch_get_ap_wake_info(void);
-struct acpi_table_header *slaunch_get_dmar_table(struct acpi_table_header *dmar);
-void slaunch_sexit(void);
+extern void slaunch_setup(void);
+extern u32 slaunch_get_flags(void);
+extern struct sl_ap_wake_info *slaunch_get_ap_wake_info(void);
+extern struct acpi_table_header *slaunch_get_dmar_table(struct acpi_table_header *dmar);
+extern void slaunch_sexit(void);
 
 #endif /* !__ASSEMBLY */
 


### PR DESCRIPTION
This one should be straight forward - it is just changing the names of some definitions.