### PR TITLE
[revision] for {447296a93c21c0e519d87fe5df16685c86d6334e}

### DIFF
--- a/arch/x86/boot/compressed/kernel_info.S
+++ b/arch/x86/boot/compressed/kernel_info.S
@@ -18,7 +18,11 @@ kernel_info:
 	.long	SETUP_TYPE_MAX
 
 	/* Offset to the MLE header structure */
+#ifdef CONFIG_SECURE_LAUNCH
 	.long	mle_header
+#else
+	.long	0
+#endif
 
 kernel_info_var_len_data:
 	/* Empty for time being... */


### PR DESCRIPTION
Add ifdef CONFIG_SECURE_LAUNCH to kernel_info

This was unfortunately discovered after the RFC went out and it
prevents building w/ CONFIG_SECURE_LAUNCH disabled.

Signed-off-by: Ross Philipson <ross.philipson@oracle.com>