### PR TITLE
[revision] for {f326a838319dd76255943b8a7008680382a8af6b}

### DIFF
--- a/arch/x86/boot/compressed/tpm/tpm2_cmds.c
+++ b/arch/x86/boot/compressed/tpm/tpm2_cmds.c
@@ -124,7 +124,7 @@ int tpm2_extend_pcr(struct tpm *t, u32 pcr,
 
 	memcpy(cmd.params, digests, size);
 
-	cmd.header->size = cpu_to_be16(tpmb_size(b));
+	cmd.header->size = cpu_to_be32(tpmb_size(b));
 
 	switch (t->intf) {
 	case TPM_DEVNODE:
@@ -132,10 +132,14 @@ int tpm2_extend_pcr(struct tpm *t, u32 pcr,
 		ret = -EBADRQC;
 		break;
 	case TPM_TIS:
-		ret = tis_send(b);
+		size = tis_send(b);
+		if (tpmb_size(b) != size)
+			ret = -EAGAIN;
 		break;
 	case TPM_CRB:
-		ret = crb_send(b);
+		size = crb_send(b);
+		if (tpmb_size(b) != size)
+			ret = -EAGAIN;
 		break;
 	case TPM_UEFI:
 		/* Not implemented yet */


### PR DESCRIPTION
Use cpu_to_be32 for the message size for TPM2 extend

Signed-off-by: Ross Philipson <ross.philipson@oracle.com>