### PR TITLE
[revision] for {2ba13df24ceca280eec1e42a3fbdc60a1f3fc4c8}

### DIFF
--- a/arch/x86/boot/compressed/sl_main.c
+++ b/arch/x86/boot/compressed/sl_main.c
@@ -18,7 +18,7 @@
 #include <asm/efi.h>
 #include <linux/slaunch.h>
 #ifdef CONFIG_SECURE_LAUNCH_SHA256
-#include <linux/sha256.h>
+#include <config/crypto/sha256.h>
 #endif
 #ifdef CONFIG_SECURE_LAUNCH_SHA512
 #include <linux/sha512.h>


### PR DESCRIPTION
Fix include location for sha256.h

Not sure why these two headers are in different places...

Signed-off-by: Ross Philipson <ross.philipson@oracle.com>