### PR TITLE
revisions for early tpm code

### DIFF
--- a/arch/x86/boot/compressed/tpm/tpm1_cmds.c
+++ b/arch/x86/boot/compressed/tpm/tpm1_cmds.c
@@ -29,6 +29,11 @@ int tpm1_pcr_extend(struct tpm *t, struct tpm_digest *d)
 	struct tpm_extend_resp *resp;
 	size_t bytes, size;
 
+	if (b == NULL) {
+		ret = -EINVAL;
+		goto out;
+	}
+
 	if (!tpmb_reserve(b)) {
 		ret = -ENOMEM;
 		goto out;

--- a/arch/x86/boot/compressed/tpm/tpm2_cmds.c
+++ b/arch/x86/boot/compressed/tpm/tpm2_cmds.c
@@ -84,6 +84,11 @@ int tpm2_extend_pcr(struct tpm *t, u32 pcr,
 	u16 size;
 	int ret = 0;
 
+	if (b == NULL) {
+		ret = -EINVAL;
+		goto out;
+	}
+
 	ret = tpm2_alloc_cmd(b, &cmd, TPM_ST_SESSIONS, TPM_CC_PCR_EXTEND);
 	if (ret < 0)
 		goto out;

--- a/arch/x86/boot/compressed/tpm/tpm_buff.c
+++ b/arch/x86/boot/compressed/tpm/tpm_buff.c
@@ -8,6 +8,7 @@
  */
 
 #include <linux/types.h>
+#include <linux/string.h>
 #include "tpm.h"
 #include "tpmbuff.h"
 #include "tpm_common.h"


### PR DESCRIPTION
Adding guards for extend command to ensure buffer has been allocated
and adding the <string.h> missing include.

Signed-off-by: Daniel P. Smith <dpsmith@apertussolutions.com>