### PR TITLE
Allow the TPM event log to reside anywhere

### DIFF
--- a/arch/x86/boot/compressed/sl_main.c
+++ b/arch/x86/boot/compressed/sl_main.c
@@ -126,7 +126,7 @@ static void sl_find_event_log(struct tpm *tpm)
 	txt_heap = (void *)sl_txt_read(TXT_CR_HEAP_BASE);
 
 	os_mle_data = txt_os_mle_data_start(txt_heap);
-	evtlog_base = (void *)&os_mle_data->event_log_buffer[0];
+	evtlog_base = (void *)os_mle_data->evtlog_addr;
 
 	if (tpm->family != TPM20)
 		return;
@@ -394,19 +394,16 @@ void sl_main(u8 *bootparams)
 		txt_heap = (void *)sl_txt_read(TXT_CR_HEAP_BASE);
 		os_mle_data = txt_os_mle_data_start(txt_heap);
 
-		/*
-		* Measure OS-MLE data up to the MLE scratch field. The MLE
-		* scratch field and the TPM logging should not be measured.
-		*/
+		/* Measure OS-MLE data up to the MLE scratch field. */
 		os_mle_len = offsetof(struct txt_os_mle_data, mle_scratch);
 		sl_tpm_extend_pcr(tpm, SL_CONFIG_PCR18, (u8 *)os_mle_data,
 				  os_mle_len,
 				  "Measured TXT OS-MLE data into PCR18");
 
 		/*
-		* Now that the OS-MLE data is measured, ensure the MTRR and
-		* misc enable MSRs are what we expect.
-		*/
+		 * Now that the OS-MLE data is measured, ensure the MTRR and
+		 * misc enable MSRs are what we expect.
+		 */
 		sl_txt_validate_msrs(os_mle_data);
 	}
 

--- a/arch/x86/kernel/slaunch.c
+++ b/arch/x86/kernel/slaunch.c
@@ -341,18 +341,16 @@ static void __init slaunch_fetch_ap_wake_block(void __iomem *txt)
 {
 	struct txt_os_mle_data *os_mle_data;
 	u8 *jmp_offset;
-	u32 field_offset;
 
-	field_offset = offsetof(struct txt_os_mle_data, event_log_buffer);
 	os_mle_data = txt_early_get_heap_table(txt, TXT_OS_MLE_DATA_TABLE,
-					       field_offset);
+					       sizeof(struct txt_os_mle_data));
 
 	ap_wake_info.ap_wake_block = os_mle_data->ap_wake_block;
 
 	jmp_offset = os_mle_data->mle_scratch + SL_SCRATCH_AP_JMP_OFFSET;
 	ap_wake_info.ap_jmp_offset = *((u32 *)jmp_offset);
 
-	early_memunmap(os_mle_data, field_offset);
+	early_memunmap(os_mle_data, sizeof(struct txt_os_mle_data));
 }
 
 /*

--- a/include/linux/slaunch.h
+++ b/include/linux/slaunch.h
@@ -93,7 +93,6 @@
 /*
  * OS/MLE Secure Launch Specific Definitions
  */
-#define TXT_MAX_EVENT_LOG_SIZE		(5*4*1024)   /* 4k*5 */
 #define TXT_MAX_VARIABLE_MTRRS		32
 #define TXT_OS_MLE_STRUCT_VERSION	1
 
@@ -230,8 +229,9 @@ struct txt_os_mle_data {
 	struct txt_mtrr_state saved_bsp_mtrrs;
 	u32 ap_wake_block;
 	u32 ap_wake_block_size;
+	u64 evtlog_addr;
+	u32 evtlog_size;
 	u8 mle_scratch[16];
-	u8 event_log_buffer[TXT_MAX_EVENT_LOG_SIZE];
 } __packed;
 
 /*


### PR DESCRIPTION
Added a base and size field so the TPM event log can be allocated anywhere. Note this does not preclude it from still residing in the TXT heap if desired.