### PR TITLE
Use memblock_reserve to reserve TXT regions and PMR hole

### DIFF
--- a/include/linux/slaunch.h
+++ b/include/linux/slaunch.h
@@ -173,6 +173,7 @@
  */
 struct sl_ap_wake_info {
 	u32 ap_wake_block;
+	u32 ap_wake_block_size;
 	u32 ap_jmp_offset;
 };
 


### PR DESCRIPTION
This closes up all the holes where we don't want the MLE to use these regions.