### PR TITLE
SEXIT on reboot paths

### DIFF
--- a/arch/x86/Kconfig
+++ b/arch/x86/Kconfig
@@ -2020,8 +2020,8 @@ config SECURE_LAUNCH
 	depends on X86_64
 	help
 	  This Secure Launch kernel feature allows a bzImage to be loaded
-	  directly through Intel TXT or AMD SKINIT measured launch. This
-	  allows extablishing a Dynamic Root of Trust Measurement (DRTM)
+	  directly through Intel TXT measured launch. This allows
+	  extablishing a Dynamic Root of Trust Measurement (DRTM)
 	  of all the modules and configuration information used for
 	  boooting the operating system.
 

--- a/arch/x86/kernel/reboot.c
+++ b/arch/x86/kernel/reboot.c
@@ -11,6 +11,7 @@
 #include <linux/tboot.h>
 #include <linux/delay.h>
 #include <linux/frame.h>
+#include <linux/slaunch.h>
 #include <acpi/reboot.h>
 #include <asm/io.h>
 #include <asm/apic.h>
@@ -724,6 +725,7 @@ static void native_machine_restart(char *__unused)
 
 	if (!reboot_force)
 		machine_shutdown();
+	slaunch_finalize(!reboot_force);
 	__machine_emergency_restart(0);
 }
 
@@ -734,6 +736,9 @@ static void native_machine_halt(void)
 
 	tboot_shutdown(TB_SHUTDOWN_HALT);
 
+	/* SEXIT done after machine_shutdown() to meet TXT requirements */
+	slaunch_finalize(1);
+
 	stop_this_cpu(NULL);
 }
 
@@ -742,8 +747,12 @@ static void native_machine_power_off(void)
 	if (pm_power_off) {
 		if (!reboot_force)
 			machine_shutdown();
+		slaunch_finalize(!reboot_force);
 		pm_power_off();
+	} else {
+		slaunch_finalize(0);
 	}
+
 	/* A fallback in case there is no PM info available */
 	tboot_shutdown(TB_SHUTDOWN_HALT);
 }
@@ -771,6 +780,7 @@ void machine_shutdown(void)
 
 void machine_emergency_restart(void)
 {
+	slaunch_finalize(0);
 	__machine_emergency_restart(1);
 }
 

--- a/include/linux/slaunch.h
+++ b/include/linux/slaunch.h
@@ -504,7 +504,7 @@ extern void slaunch_setup(void);
 extern u32 slaunch_get_flags(void);
 extern struct sl_ap_wake_info *slaunch_get_ap_wake_info(void);
 extern struct acpi_table_header *slaunch_get_dmar_table(struct acpi_table_header *dmar);
-extern void slaunch_sexit(void);
+extern void slaunch_finalize(int do_sexit);
 
 #endif /* !__ASSEMBLY */
 
@@ -513,7 +513,7 @@ extern void slaunch_sexit(void);
 #define slaunch_setup()			do { } while (0)
 #define slaunch_get_flags()		0
 #define slaunch_get_dmar_table(d)	(d)
-#define slaunch_sexit()			do { } while (0)
+#define slaunch_finalize(d)		do { } while (0)
 
 #endif /* !CONFIG_SECURE_LAUNCH */
 

--- a/kernel/kexec_core.c
+++ b/kernel/kexec_core.c
@@ -1175,7 +1175,8 @@ int kernel_kexec(void)
 		pr_emerg("Starting new kernel\n");
 		machine_shutdown();
 
-		slaunch_sexit();
+		/* Finalize TXT registers and do SEXIT */
+		slaunch_finalize(1);
 	}
 
 	machine_kexec(kexec_image);


### PR DESCRIPTION
The commit "reboot: Secure Launch SEXIT support on reboot paths" will go out as a separate patch. During the rebase, it should be right after the "kexec: Secure Launch kexec SEXIT support" commit.

Note the PR has a minor unrelated commit for removing AMD refs from Kconfig