### PR TITLE
[revision] for {4588fa415fa1b713bd0d669d91cd62aafc29cbe2}

### DIFF
--- a/arch/x86/boot/compressed/sl_stub.S
+++ b/arch/x86/boot/compressed/sl_stub.S
@@ -209,9 +209,6 @@ SYM_FUNC_START(sl_stub)
 	ud2
 
 .Ldo_amd:
-	/* Save our base pointer reg */
-	pushl	%ebx
-
 	cmpl	$(AMD_CPUID_MFGID_EBX), %ebx
 	jnz	.Ldo_unknown_cpu
 	cmpl	$(AMD_CPUID_MFGID_EDX), %edx
@@ -219,6 +216,7 @@ SYM_FUNC_START(sl_stub)
 	cmpl	$(AMD_CPUID_MFGID_ECX), %ecx
 	jnz	.Ldo_unknown_cpu
 
+	/* Base pointer reg saved in Intel check */
 	popl	%ebx
 
 	/* Know it is AMD */


### PR DESCRIPTION
Remove extra push %ebx. It was already pushed by the Intel check
above.

Signed-off-by: Ross Philipson <ross.philipson@oracle.com>