### PR TITLE
[revision] for {31ce1a54f39520f54fa7e1b4df9263ea035a1816}

### DIFF
--- a/arch/x86/boot/compressed/early_sha256.c
+++ b/arch/x86/boot/compressed/early_sha256.c
@@ -3,4 +3,5 @@
  * Copyright (c) 2020 Apertus Solutions, LLC
  */
 
+#define SHA256_DISABLE_EXPORT
 #include "../../../../lib/crypto/sha256.c"

--- a/lib/crypto/sha256.c
+++ b/lib/crypto/sha256.c
@@ -233,13 +233,17 @@ void sha256_update(struct sha256_state *sctx, const u8 *data, unsigned int len)
 	}
 	memcpy(sctx->buf + partial, src, len - done);
 }
+#ifndef SHA256_DISABLE_EXPORT
 EXPORT_SYMBOL(sha256_update);
+#endif
 
 void sha224_update(struct sha256_state *sctx, const u8 *data, unsigned int len)
 {
 	sha256_update(sctx, data, len);
 }
+#ifndef SHA256_DISABLE_EXPORT
 EXPORT_SYMBOL(sha224_update);
+#endif
 
 static void __sha256_final(struct sha256_state *sctx, u8 *out, int digest_words)
 {
@@ -272,12 +276,16 @@ void sha256_final(struct sha256_state *sctx, u8 *out)
 {
 	__sha256_final(sctx, out, 8);
 }
+#ifndef SHA256_DISABLE_EXPORT
 EXPORT_SYMBOL(sha256_final);
+#endif
 
 void sha224_final(struct sha256_state *sctx, u8 *out)
 {
 	__sha256_final(sctx, out, 7);
 }
+#ifndef SHA256_DISABLE_EXPORT
 EXPORT_SYMBOL(sha224_final);
+#endif
 
 MODULE_LICENSE("GPL");


### PR DESCRIPTION
With newer GCC packages, the exports in the sha256.c code cause
problem in the PIE compressed kernel. This conditionally removes
the exporting.

Signed-off-by: Ross Philipson <ross.philipson@oracle.com>