### PR TITLE
Fix testing of SL_FLAGS when determining if SL is TXT and active

### DIFF
--- a/arch/x86/kernel/slaunch.c
+++ b/arch/x86/kernel/slaunch.c
@@ -796,7 +796,8 @@ void slaunch_finalize(int do_sexit)
 	void __iomem *config;
 	u64 one = 1, val;
 
-	if (!(slaunch_get_flags() & (SL_FLAG_ACTIVE|SL_FLAG_ARCH_TXT)))
+	if ((slaunch_get_flags() & (SL_FLAG_ACTIVE|SL_FLAG_ARCH_TXT)) !=
+	    (SL_FLAG_ACTIVE|SL_FLAG_ARCH_TXT))
 		return;
 
 	config = ioremap(TXT_PRIV_CONFIG_REGS_BASE, TXT_NR_CONFIG_PAGES *
@@ -815,8 +816,8 @@ void slaunch_finalize(int do_sexit)
 	memcpy_fromio(&val, config + TXT_CR_E2STS, sizeof(u64));
 
 	/* Close the TXT private register space */
-	memcpy_fromio(&val, config + TXT_CR_E2STS, sizeof(u64));
 	memcpy_toio(config + TXT_CR_CMD_CLOSE_PRIVATE, &one, sizeof(u64));
+	memcpy_fromio(&val, config + TXT_CR_E2STS, sizeof(u64));
 
 	/*
 	 * Calls to iounmap are not being done because of the state of the

--- a/arch/x86/kernel/smpboot.c
+++ b/arch/x86/kernel/smpboot.c
@@ -1160,7 +1160,8 @@ static int do_boot_cpu(int apicid, int cpu, struct task_struct *idle,
 	smp_mb();
 
 	/* With Intel TXT, the AP startup is totally different */
-	if (slaunch_get_flags() & (SL_FLAG_ACTIVE|SL_FLAG_ARCH_TXT)) {
+	if ((slaunch_get_flags() & (SL_FLAG_ACTIVE|SL_FLAG_ARCH_TXT)) ==
+	   (SL_FLAG_ACTIVE|SL_FLAG_ARCH_TXT)) {
 		boot_error = slaunch_wakeup_cpu_from_txt(cpu, apicid);
 		goto txt_wake;
 	}

--- a/drivers/char/tpm/tpm-chip.c
+++ b/drivers/char/tpm/tpm-chip.c
@@ -40,7 +40,7 @@ static int tpm_request_locality(struct tpm_chip *chip)
 	if (!chip->ops->request_locality)
 		return 0;
 
-	if (slaunch_get_flags() & (SL_FLAG_ACTIVE|SL_FLAG_ARCH_TXT)) {
+	if (slaunch_get_flags() & SL_FLAG_ACTIVE) {
 		dev_dbg(&chip->dev, "setting TPM locality to 2 for MLE\n");
 		locality = 2;
 	} else {


### PR DESCRIPTION
Fix testing of SL_FLAGS when determining if SL is TXT and active.