### PR TITLE
Allow use of alternate PCR 19 and 20 for post ACM measurements

### DIFF
--- a/arch/x86/Kconfig
+++ b/arch/x86/Kconfig
@@ -2003,6 +2003,26 @@ config SECURE_LAUNCH_SHA512
 
 endchoice
 
+config SECURE_LAUNCH_ALT_PCR19
+	bool "Secure Launch Alternate PCR 19 usage"
+	default n
+	depends on SECURE_LAUNCH
+	help
+	   In the post ACM environment, Secure Launch by default measures
+	   configuration information into PCR18. This feature allows finer
+	   control over measurements by moving configuration measurements
+	   into PCR19.
+
+config SECURE_LAUNCH_ALT_PCR20
+	bool "Secure Launch Alternate PCR 20 usage"
+	default n
+	depends on SECURE_LAUNCH
+	help
+	   In the post ACM environment, Secure Launch by default measures
+	   image data like any external initrd into PCR17. This feature
+	   allows finer control over measurements by moving image measurements
+	   into PCR20.
+
 config SECCOMP
 	def_bool y
 	prompt "Enable seccomp to safely compute untrusted bytecode"

--- a/include/linux/slaunch.h
+++ b/include/linux/slaunch.h
@@ -161,8 +161,10 @@
 /*
  * Measured Launch PCRs
  */
-#define SL_IMAGE_PCR17		17
-#define SL_CONFIG_PCR18		18
+#define SL_DEF_IMAGE_PCR17	17 /* TCG Details PCR */
+#define SL_DEF_CONFIG_PCR18	18 /* TCG Authorities PCR */
+#define SL_ALT_CONFIG_PCR19	19
+#define SL_ALT_IMAGE_PCR20	20
 
 /*
  * MLE scratch area offsets


### PR DESCRIPTION
Use of PCRs 19 and 20 can be set independently via Kconfig.