### PR TITLE
Validate the event log container size

### DIFF
--- a/arch/x86/boot/compressed/sl_main.c
+++ b/arch/x86/boot/compressed/sl_main.c
@@ -243,7 +243,7 @@ static void sl_tpm12_log_event(u32 pcr, u8 *digest,
 
 	total_size = sizeof(struct tpm12_pcr_event) + event_size;
 
-	if (tpm12_log_event(evtlog_base, total_size, pcr_event))
+	if (tpm12_log_event(evtlog_base, evtlog_size, total_size, pcr_event))
 		sl_txt_reset(SL_ERROR_TPM_LOGGING_FAILED);
 }
 
@@ -294,7 +294,7 @@ static void sl_tpm20_log_event(u32 pcr, u8 *digest, u16 algo,
 	total_size = (u32)((u8 *)tail - (u8 *)head) +
 		sizeof(struct tpm20_pcr_event_tail) + event_size;
 
-	if (tpm20_log_event(log20_elem, evtlog_base, total_size, &log_buf[0]))
+	if (tpm20_log_event(log20_elem, evtlog_base, evtlog_size, total_size, &log_buf[0]))
 		sl_txt_reset(SL_ERROR_TPM_LOGGING_FAILED);
 }
 

--- a/arch/x86/kernel/slaunch.c
+++ b/arch/x86/kernel/slaunch.c
@@ -593,9 +593,10 @@ static ssize_t sl_evtlog_write(struct file *file, const char __user *buf,
 	mutex_lock(&sl_evt_log_mutex);
 	if (evtlog20)
 		result = tpm20_log_event(evtlog20, sl_evtlog.addr,
-					 datalen, data);
+					 sl_evtlog.size, datalen, data);
 	else
-		result = tpm12_log_event(sl_evtlog.addr, datalen, data);
+		result = tpm12_log_event(sl_evtlog.addr, sl_evtlog.size,
+					 datalen, data);
 	mutex_unlock(&sl_evt_log_mutex);
 
 	kfree(data);

--- a/include/linux/slaunch.h
+++ b/include/linux/slaunch.h
@@ -482,7 +482,7 @@ tpm20_find_log2_1_element(struct txt_os_sinit_data *os_sinit_data)
 	return NULL;
 }
 
-static inline int tpm12_log_event(void *evtlog_base,
+static inline int tpm12_log_event(void *evtlog_base, u32 evtlog_size,
 				  u32 event_size, void *event)
 {
 	struct tpm12_event_log_header *evtlog =
@@ -490,6 +490,9 @@ static inline int tpm12_log_event(void *evtlog_base,
 
 	if (memcmp(evtlog->signature, TPM12_EVTLOG_SIGNATURE,
 		   sizeof(TPM12_EVTLOG_SIGNATURE)))
+		return -EINVAL;
+
+	if (evtlog->container_size > evtlog_size)
 		return -EINVAL;
 
 	if (evtlog->next_event_offset + event_size > evtlog->container_size)
@@ -502,7 +505,7 @@ static inline int tpm12_log_event(void *evtlog_base,
 }
 
 static inline int tpm20_log_event(struct txt_heap_event_log_pointer2_1_element *elem,
-				  void *evtlog_base,
+				  void *evtlog_base, u32 evtlog_size,
 				  u32 event_size, void *event)
 {
 	struct tpm12_pcr_event *header =
@@ -514,6 +517,9 @@ static inline int tpm20_log_event(struct txt_heap_event_log_pointer2_1_element *
 
 	if (memcmp((u8 *)header + sizeof(struct tpm12_pcr_event),
 		   TPM20_EVTLOG_SIGNATURE, sizeof(TPM20_EVTLOG_SIGNATURE)))
+		return -EINVAL;
+
+	if (elem->allocated_event_container_size > evtlog_size)
 		return -EINVAL;
 
 	if (elem->next_record_offset + event_size >


### PR DESCRIPTION
Ensure that the event log container size is less than or equal to the overall event log allocatd buffer.