### PR TITLE
iommu: Do not allow IOMMU passthrough with Secure Launch

### DIFF
--- a/drivers/iommu/intel/iommu.c
+++ b/drivers/iommu/intel/iommu.c
@@ -2828,6 +2828,10 @@ static bool device_is_rmrr_locked(struct device *dev)
  */
 static int device_def_domain_type(struct device *dev)
 {
+	/* Do not allow identity domain when Secure Launch is configured */
+	if (!IS_ENABLED(CONFIG_SECURE_LAUNCH))
+		return IOMMU_DOMAIN_DMA;
+
 	if (dev_is_pci(dev)) {
 		struct pci_dev *pdev = to_pci_dev(dev);
 

--- a/drivers/iommu/iommu.c
+++ b/drivers/iommu/iommu.c
@@ -2556,7 +2556,9 @@ void iommu_set_default_passthrough(bool cmd_line)
 	if (cmd_line)
 		iommu_set_cmd_line_dma_api();
 
-	iommu_def_domain_type = IOMMU_DOMAIN_IDENTITY;
+	/* Do not allow identity domain when Secure Launch is configured */
+	if (!IS_ENABLED(CONFIG_SECURE_LAUNCH))
+		iommu_def_domain_type = IOMMU_DOMAIN_IDENTITY;
 }
 
 void iommu_set_default_translated(bool cmd_line)


### PR DESCRIPTION
The IOMMU should always be set to default translated type after
the PMRs are disabled to protect the MLE from DMA.

This is a new patch should be placed after the tpm patch in the main patch set.

Signed-off-by: Ross Philipson <ross.philipson@oracle.com>