### PR TITLE
Add Kconfig constraints needed by Secure Launch

### DIFF
--- a/arch/x86/Kconfig
+++ b/arch/x86/Kconfig
@@ -1970,7 +1970,7 @@ config EFI_MIXED
 config SECURE_LAUNCH
 	bool "Secure Launch support"
 	default n
-	depends on X86_64
+	depends on X86_64 && X86_X2APIC && !RANDOMIZE_BASE
 	help
 	   The Secure Launch feature allows a kernel to be loaded
 	   directly through an Intel TXT measured launch. Intel TXT


### PR DESCRIPTION
Add Kconfig constraints needed by Secure Launch

Force KASLR off; Secure Launch cannot interoperate with randomizing
the locations of things.

The AP wake code depends on x2apic support.

[set 7]

Signed-off-by: Ross Philipson <ross.philipson@oracle.com>