### PR TITLE
Runtime checks to disable certain features

### DIFF
--- a/arch/x86/Kconfig
+++ b/arch/x86/Kconfig
@@ -1995,7 +1995,7 @@ config EFI_MIXED
 config SECURE_LAUNCH
 	bool "Secure Launch support"
 	default n
-	depends on X86_64 && X86_X2APIC && !RANDOMIZE_BASE
+	depends on X86_64 && X86_X2APIC
 	help
 	   The Secure Launch feature allows a kernel to be loaded
 	   directly through an Intel TXT measured launch. Intel TXT

--- a/arch/x86/boot/compressed/kaslr.c
+++ b/arch/x86/boot/compressed/kaslr.c
@@ -29,6 +29,7 @@
 #include <linux/utsname.h>
 #include <linux/ctype.h>
 #include <linux/efi.h>
+#include <linux/slaunch.h>
 #include <generated/utsrelease.h>
 #include <asm/efi.h>
 
@@ -837,6 +838,16 @@ void choose_random_location(unsigned long input,
 
 	if (cmdline_find_option_bool("nokaslr")) {
 		warn("KASLR disabled: 'nokaslr' on cmdline.");
+		return;
+	}
+
+	/*
+	 * If a secure launch is in progress, KASLR cannot be used
+	 * since knowing the exact location of things is a crucial
+	 * part of the secure launch.
+	 */
+	if (slaunch_get_cpu_type() & SL_CPU_INTEL) {
+		warn("KASLR disabled: by Secure Launch");
 		return;
 	}
 

--- a/arch/x86/boot/compressed/sl_main.c
+++ b/arch/x86/boot/compressed/sl_main.c
@@ -62,6 +62,11 @@ static u32 pcr_image = SL_ALT_IMAGE_PCR20;
 extern u32 sl_cpu_type;
 extern u32 sl_mle_start;
 
+u32 slaunch_get_cpu_type(void)
+{
+	return sl_cpu_type;
+}
+
 static u64 sl_txt_read(u32 reg)
 {
 	return readq((void *)(u64)(TXT_PRIV_CONFIG_REGS_BASE + reg));

--- a/drivers/iommu/intel/iommu.c
+++ b/drivers/iommu/intel/iommu.c
@@ -41,6 +41,7 @@
 #include <linux/dma-direct.h>
 #include <linux/crash_dump.h>
 #include <linux/numa.h>
+#include <linux/slaunch.h>
 #include <asm/irq_remapping.h>
 #include <asm/cacheflush.h>
 #include <asm/iommu.h>
@@ -2850,7 +2851,7 @@ static bool device_is_rmrr_locked(struct device *dev)
 static int device_def_domain_type(struct device *dev)
 {
 	/* Do not allow identity domain when Secure Launch is configured */
-	if (!IS_ENABLED(CONFIG_SECURE_LAUNCH))
+	if (slaunch_get_flags() & SL_FLAG_ACTIVE)
 		return IOMMU_DOMAIN_DMA;
 
 	if (dev_is_pci(dev)) {

--- a/drivers/iommu/iommu.c
+++ b/drivers/iommu/iommu.c
@@ -23,6 +23,7 @@
 #include <linux/property.h>
 #include <linux/fsl/mc.h>
 #include <linux/module.h>
+#include <linux/slaunch.h>
 #include <trace/events/iommu.h>
 
 static struct kset *iommu_group_kset;
@@ -2780,7 +2781,7 @@ void iommu_set_default_passthrough(bool cmd_line)
 		iommu_set_cmd_line_dma_api();
 
 	/* Do not allow identity domain when Secure Launch is configured */
-	if (!IS_ENABLED(CONFIG_SECURE_LAUNCH))
+	if (!(slaunch_get_flags() & SL_FLAG_ACTIVE))
 		iommu_def_domain_type = IOMMU_DOMAIN_IDENTITY;
 }
 

--- a/include/linux/slaunch.h
+++ b/include/linux/slaunch.h
@@ -15,13 +15,16 @@
 #define SL_FLAG_ARCH_SKINIT	0x00000002
 #define SL_FLAG_ARCH_TXT	0x00000004
 
+/*
+ * Secure Launch CPU Type
+ */
+#define SL_CPU_AMD	1
+#define SL_CPU_INTEL	2
+
 #if IS_ENABLED(CONFIG_SECURE_LAUNCH)
 
 #define __SL32_CS	0x0008
 #define __SL32_DS	0x0010
-
-#define SL_CPU_AMD	1
-#define SL_CPU_INTEL	2
 
 #define INTEL_CPUID_MFGID_EBX	0x756e6547 /* Genu */
 #define INTEL_CPUID_MFGID_EDX	0x49656e69 /* ineI */
@@ -503,7 +506,12 @@ static inline int tpm20_log_event(struct txt_heap_event_log_pointer2_1_element *
 }
 
 /*
- * External functions
+ * External functions avalailable in compressed kernel.
+ */
+extern u32 slaunch_get_cpu_type(void);
+
+/*
+ * External functions avalailable in mainline kernel.
  */
 extern void slaunch_setup(void);
 extern u32 slaunch_get_flags(void);
@@ -517,6 +525,7 @@ extern void slaunch_finalize(int do_sexit);
 
 #else
 
+#define slaunch_get_cpu_type()		0
 #define slaunch_setup()			do { } while (0)
 #define slaunch_get_flags()		0
 #define slaunch_get_dmar_table(d)	(d)


### PR DESCRIPTION
Instead of using compile time checks for disabling KASLR and preventing IOMMU passthrough mode, use runtime checks. This means these features can be available when the kernel is booted w/o secure launch.