### PR TITLE
Use CPUID SMX feature bit

### DIFF
--- a/arch/x86/boot/compressed/sl_stub.S
+++ b/arch/x86/boot/compressed/sl_stub.S
@@ -17,6 +17,9 @@
 #include <asm/irq_vectors.h>
 #include <linux/slaunch.h>
 
+/* CPUID: leaf 1, ECX, SMX feature bit */
+#define X86_FEATURE_BIT_SMX	6
+
 /* Can't include apiddef.h in asm */
 #define XAPIC_ENABLE	(1 << 11)
 #define X2APIC_ENABLE	(1 << 10)
@@ -104,15 +107,11 @@ SYM_FUNC_START(sl_stub_entry)
 	pushl	%ebx
 	pushl	%ecx
 
-	/* Now see if it is GenuineIntel. CPUID 0 returns the manufacturer */
-	xorl	%eax, %eax
+	/* See if SMX feature is supported. */
+	movl	$1, %eax
 	cpuid
-	cmpl	$(INTEL_CPUID_MFGID_EBX), %ebx
-	jnz	.Ldo_unknown_cpu
-	cmpl	$(INTEL_CPUID_MFGID_EDX), %edx
-	jnz	.Ldo_unknown_cpu
-	cmpl	$(INTEL_CPUID_MFGID_ECX), %ecx
-	jnz	.Ldo_unknown_cpu
+	testl	$(X86_FEATURE_BIT_SMX), %ecx
+	jz	.Ldo_unknown_cpu
 
 	popl	%ecx
 	popl	%ebx

--- a/arch/x86/kernel/setup.c
+++ b/arch/x86/kernel/setup.c
@@ -994,7 +994,7 @@ void __init setup_arch(char **cmdline_p)
 	early_gart_iommu_check();
 #endif
 
-	slaunch_setup();
+	slaunch_setup_txt();
 
 	/*
 	 * partially used pages are not usable - thus

--- a/arch/x86/kernel/slaunch.c
+++ b/arch/x86/kernel/slaunch.c
@@ -378,9 +378,9 @@ static void __init slaunch_fetch_os_mle_fields(void __iomem *txt)
 }
 
 /*
- * Intel specific late stub setup and validation.
+ * Intel TXT specific late stub setup and validation.
  */
-static void __init slaunch_setup_intel(void)
+void __init slaunch_setup_txt(void)
 {
 	void __iomem *txt;
 	u64 one = TXT_REGVALUE_ONE, val;
@@ -457,20 +457,6 @@ static void __init slaunch_setup_intel(void)
 	early_iounmap(txt, TXT_NR_CONFIG_PAGES * PAGE_SIZE);
 
 	pr_info("Intel TXT setup complete\n");
-}
-
-void __init slaunch_setup(void)
-{
-	u32 vendor[4];
-
-	/* Get manufacturer string with CPUID 0 */
-	cpuid(0, &vendor[0], &vendor[1], &vendor[2], &vendor[3]);
-
-	/* Only Intel TXT is supported at this point */
-	if (vendor[1] == INTEL_CPUID_MFGID_EBX &&
-	    vendor[2] == INTEL_CPUID_MFGID_ECX &&
-	    vendor[3] == INTEL_CPUID_MFGID_EDX)
-		slaunch_setup_intel();
 }
 
 static inline void smx_getsec_sexit(void)

--- a/include/linux/slaunch.h
+++ b/include/linux/slaunch.h
@@ -26,14 +26,6 @@
 #define __SL32_CS	0x0008
 #define __SL32_DS	0x0010
 
-#define INTEL_CPUID_MFGID_EBX	0x756e6547 /* Genu */
-#define INTEL_CPUID_MFGID_EDX	0x49656e69 /* ineI */
-#define INTEL_CPUID_MFGID_ECX	0x6c65746e /* ntel */
-
-#define AMD_CPUID_MFGID_EBX	0x68747541 /* Auth */
-#define AMD_CPUID_MFGID_EDX	0x69746e65 /* enti */
-#define AMD_CPUID_MFGID_ECX	0x444d4163 /* cAMD */
-
 /*
  * Intel Safer Mode Extensions (SMX)
  *
@@ -517,7 +509,7 @@ extern u32 slaunch_get_cpu_type(void);
 /*
  * External functions avalailable in mainline kernel.
  */
-extern void slaunch_setup(void);
+extern void slaunch_setup_txt(void);
 extern u32 slaunch_get_flags(void);
 extern struct sl_ap_wake_info *slaunch_get_ap_wake_info(void);
 extern struct acpi_table_header *slaunch_get_dmar_table(struct acpi_table_header *dmar);
@@ -530,7 +522,7 @@ extern void slaunch_finalize(int do_sexit);
 #else
 
 #define slaunch_get_cpu_type()		0
-#define slaunch_setup()			do { } while (0)
+#define slaunch_setup_txt()		do { } while (0)
 #define slaunch_get_flags()		0
 #define slaunch_get_dmar_table(d)	(d)
 #define slaunch_finalize(d)		do { } while (0)


### PR DESCRIPTION
Using the feature bit instead of the vendor information was suggested by Andrew Cooper. It is a more precise way to determine if the platform supports secure launch.