### PR TITLE
No disabling special cases for Secure Launch

### DIFF
--- a/arch/x86/boot/compressed/kaslr.c
+++ b/arch/x86/boot/compressed/kaslr.c
@@ -29,7 +29,6 @@
 #include <linux/utsname.h>
 #include <linux/ctype.h>
 #include <linux/efi.h>
-#include <linux/slaunch.h>
 #include <generated/utsrelease.h>
 #include <asm/efi.h>
 
@@ -838,16 +837,6 @@ void choose_random_location(unsigned long input,
 
 	if (cmdline_find_option_bool("nokaslr")) {
 		warn("KASLR disabled: 'nokaslr' on cmdline.");
-		return;
-	}
-
-	/*
-	 * If a secure launch is in progress, KASLR cannot be used
-	 * since knowing the exact location of things is a crucial
-	 * part of the secure launch.
-	 */
-	if (slaunch_get_cpu_type() & SL_CPU_INTEL) {
-		warn("KASLR disabled: by Secure Launch");
 		return;
 	}
 

--- a/drivers/iommu/intel/iommu.c
+++ b/drivers/iommu/intel/iommu.c
@@ -41,7 +41,6 @@
 #include <linux/dma-direct.h>
 #include <linux/crash_dump.h>
 #include <linux/numa.h>
-#include <linux/slaunch.h>
 #include <asm/irq_remapping.h>
 #include <asm/cacheflush.h>
 #include <asm/iommu.h>
@@ -2878,10 +2877,6 @@ static bool device_is_rmrr_locked(struct device *dev)
  */
 static int device_def_domain_type(struct device *dev)
 {
-	/* Do not allow identity domain when Secure Launch is configured */
-	if (slaunch_get_flags() & SL_FLAG_ACTIVE)
-		return IOMMU_DOMAIN_DMA;
-
 	if (dev_is_pci(dev)) {
 		struct pci_dev *pdev = to_pci_dev(dev);
 

--- a/drivers/iommu/iommu.c
+++ b/drivers/iommu/iommu.c
@@ -23,7 +23,6 @@
 #include <linux/property.h>
 #include <linux/fsl/mc.h>
 #include <linux/module.h>
-#include <linux/slaunch.h>
 #include <trace/events/iommu.h>
 
 static struct kset *iommu_group_kset;
@@ -2762,10 +2761,7 @@ void iommu_set_default_passthrough(bool cmd_line)
 {
 	if (cmd_line)
 		iommu_cmd_line |= IOMMU_CMD_LINE_DMA_API;
-
-	/* Do not allow identity domain when Secure Launch is configured */
-	if (!(slaunch_get_flags() & SL_FLAG_ACTIVE))
-		iommu_def_domain_type = IOMMU_DOMAIN_IDENTITY;
+	iommu_def_domain_type = IOMMU_DOMAIN_IDENTITY;
 }
 
 void iommu_set_default_translated(bool cmd_line)


### PR DESCRIPTION
Per the comment from the LKML v2 post, adding special case disabling of features like IOMMU passthrough and KASLR is not going to go over well and is not good form. We can just avoid this via configuration and settings at runtime.