### PR TITLE
[revision] for {c6b66cb80abb08afd8719e4597fbbbd8943a6d2a}

### DIFF
--- a/arch/x86/boot/compressed/sl_stub.S
+++ b/arch/x86/boot/compressed/sl_stub.S
@@ -18,7 +18,7 @@
 #include <linux/slaunch.h>
 
 /* CPUID: leaf 1, ECX, SMX feature bit */
-#define X86_FEATURE_BIT_SMX	6
+#define X86_FEATURE_BIT_SMX	(1 << 6)
 
 /* Can't include apiddef.h in asm */
 #define XAPIC_ENABLE	(1 << 11)


### PR DESCRIPTION
Fix define for CPUID SMX feature bit.

Signed-off-by: Ross Philipson <ross.philipson@oracle.com>