### PR TITLE
[revision] for {cae676ead103dbc385d27a6fdce0c4ff83b0083f}

### DIFF
--- a/arch/x86/boot/compressed/sl_stub.S
+++ b/arch/x86/boot/compressed/sl_stub.S
@@ -21,7 +21,7 @@
 #define X86_FEATURE_BIT_SMX	(1 << 6)
 
 /* CPUID: leaf 0x80000001, ECX, SKINIT feature bit */
-#define X86_FEATURE_BIT_SKINIT	12
+#define X86_FEATURE_BIT_SKINIT	(1 << 12)
 
 /* Can't include apiddef.h in asm */
 #define XAPIC_ENABLE	(1 << 11)


### PR DESCRIPTION
Fix define for CPUID SMX feature bit.