### PR TITLE
[revision] for {3e3f8e7d105cf68f0dfded4ee38a0200533547bc}

### DIFF
--- a/arch/x86/kernel/slmodule.c
+++ b/arch/x86/kernel/slmodule.c
@@ -345,8 +345,8 @@ static void slaunch_skinit_evtlog(void)
 			ind = NULL;
 		}
 
-		memunmap(data);
 		pa_data = data->next;
+		memunmap(data);
 	}
 
 	if (!ind)


### PR DESCRIPTION
Get next data pointer before unmapping memory.

Signed-off-by: Ross Philipson <ross.philipson@oracle.com>