### PR TITLE
Introduce DL stub support

### DIFF
--- a/arch/x86/boot/compressed/sl_main.c
+++ b/arch/x86/boot/compressed/sl_main.c
@@ -148,7 +148,7 @@ static void sl_check_pmr_coverage(void *base, u32 size, bool allow_hi)
  */
 static void sl_txt_validate_msrs(struct txt_os_mle_data *os_mle_data)
 {
-	struct txt_mtrr_state *saved_bsp_mtrrs;
+	struct slr_txt_mtrr_state *saved_bsp_mtrrs;
 	u64 mtrr_caps, mtrr_def_type, mtrr_var;
 	struct slr_entry_intel_info *txt_info;
 	u64 misc_en_msr;
@@ -507,15 +507,17 @@ static void sl_process_extend_policy(struct slr_table *slrt)
 static void sl_process_extend_efi_config(struct slr_table *slrt)
 {
 	struct slr_entry_efi_config *efi_config;
-	struct efi_cfg_entry *efi_entry;
+	struct slr_efi_cfg_entry *efi_entry;
 	u64 i;
 
 	efi_config =(struct slr_entry_efi_config *)
 		slr_next_entry_by_tag(slrt, NULL, SLR_ENTRY_EFI_CONFIG);
-	if (!efi_config)
-		sl_txt_reset(SL_ERROR_SLRT_MISSING_ENTRY);
 
-	efi_entry = (struct efi_cfg_entry *)((u8 *)efi_config + sizeof(*efi_config));
+	/* Optionally here depending on how SL kernel was booted */
+	if (!efi_config)
+		return;
+
+	efi_entry = (struct slr_efi_cfg_entry *)((u8 *)efi_config + sizeof(*efi_config));
 
 	for ( ; i < efi_config->nr_entries; i++, efi_entry++) {
 		sl_tpm_extend_evtlog(efi_entry->pcr, TXT_EVTYPE_SLAUNCH,

--- a/include/linux/slr_table.h
+++ b/include/linux/slr_table.h
@@ -2,7 +2,7 @@
 /*
  * Secure Launch Resource Table
  *
- * Copyright (c) 2022, Oracle and/or its affiliates.
+ * Copyright (c) 2023, Oracle and/or its affiliates.
  */
 
 #ifndef _LINUX_SLR_TABLE_H
@@ -95,8 +95,8 @@ struct slr_bl_context
  */
 struct slr_entry_dl_info {
 	struct slr_entry_hdr hdr;
-	u64 dl_handler;
 	struct slr_bl_context bl_context;
+	u64 dl_handler;
 	u64 dce_base;
 	u32 dce_size;
 	u64 dlme_entry;
@@ -182,6 +182,8 @@ struct slr_entry_efi_config {
 } __packed;
 
 struct efi_cfg_entry {
+	u16 pcr;
+	u16 reserved;
 	u64 cfg; /* address or value */
 	u32 size;
 	char evt_info[TPM_EVENT_INFO_LENGTH];


### PR DESCRIPTION
The DL stub framework allows an SL kernel to be booted via EFI and then perform the DL event after EBS by calling back through the DL stub module.