### PR TITLE
[revision] for {138f1b8aaafa8e80a3dd781df64b8cc04437a41f}

### DIFF
--- a/arch/x86/kernel/smpboot.c
+++ b/arch/x86/kernel/smpboot.c
@@ -1036,7 +1036,7 @@ static inline void slaunch_wakeup_cpu_from_txt(int cpu, int apicid)
 static int do_boot_cpu(int apicid, int cpu, struct task_struct *idle)
 {
 	unsigned long start_ip = real_mode_header->trampoline_start;
-	int ret;
+	int ret = 0;
 
 #ifdef CONFIG_X86_64
 	/* If 64-bit wakeup method exists, use the 64-bit mode trampoline IP */


### PR DESCRIPTION
Initialize ret = 0 since the Secure Launch SMP startup code does not set it.