### PR TITLE
Modifications to the SLRT from comments on the v8 patchset

### DIFF
--- a/arch/x86/kernel/slaunch.c
+++ b/arch/x86/kernel/slaunch.c
@@ -397,7 +397,7 @@ static void __init slaunch_fetch_values(void __iomem *txt)
 		slaunch_txt_reset(txt, "Error early_memremap of SLRT failed\n",
 				  SL_ERROR_SLRT_MAP);
 
-	log_info = (struct slr_entry_log_info *)slr_next_entry_by_tag(slrt, NULL, SLR_ENTRY_LOG_INFO);
+	log_info = slr_next_entry_by_tag(slrt, NULL, SLR_ENTRY_LOG_INFO);
 
 	if (!log_info)
 		slaunch_txt_reset(txt, "SLRT missing logging info entry\n",

--- a/arch/x86/kernel/slmodule.c
+++ b/arch/x86/kernel/slmodule.c
@@ -279,7 +279,7 @@ static void slaunch_intel_evtlog(void __iomem *txt)
 		slaunch_txt_reset(txt, "Error failed to memremap SLR Table\n",
 				  SL_ERROR_SLRT_MAP);
 
-	log_info = (struct slr_entry_log_info *)slr_next_entry_by_tag(slrt, NULL, SLR_ENTRY_LOG_INFO);
+	log_info = slr_next_entry_by_tag(slrt, NULL, SLR_ENTRY_LOG_INFO);
 	if (!log_info)
 		slaunch_txt_reset(txt, "Error failed to memremap SLR Table\n",
 				  SL_ERROR_SLRT_MISSING_ENTRY);


### PR DESCRIPTION
Changes:
     - Use flex arrays in structs
     - Pad everything for 8b alignment of all structs
     - Change find next functions to return void * to make casting implicit
     - Add DLME base and size field to DL info
     - Fix a few comments
     - General changes to code for SLRT changes
     - Cast DL handler address to function pointer and call directly
       (removing the inline asm jmp)