### PR TITLE
V8 Changes

### DIFF
--- a/Documentation/arch/x86/boot.rst
+++ b/Documentation/arch/x86/boot.rst
@@ -484,7 +484,7 @@ Protocol:	2.00+
 
   Bit 2 (kernel internal): SLAUNCH_FLAG
 
-	- Used internally by the compressed kernel to communicate
+	- Used internally by the setup kernel to communicate
 	  Secure Launch status to kernel proper.
 
 	    - If 1, Secure Launch enabled.

--- a/arch/x86/Kconfig
+++ b/arch/x86/Kconfig
@@ -2068,8 +2068,7 @@ config EFI_RUNTIME_MAP
 
 config SECURE_LAUNCH
 	bool "Secure Launch support"
-	default n
-	depends on X86_64 && X86_X2APIC
+	depends on X86_64 && X86_X2APIC && TCG_TPM && CRYPTO_LIB_SHA1 && CRYPTO_LIB_SHA256
 	help
 	   The Secure Launch feature allows a kernel to be loaded
 	   directly through an Intel TXT measured launch. Intel TXT

--- a/arch/x86/boot/compressed/head_64.S
+++ b/arch/x86/boot/compressed/head_64.S
@@ -416,14 +416,10 @@ SYM_CODE_START(startup_64)
 	popfq
 
 #ifdef CONFIG_SECURE_LAUNCH
-	pushq	%rsi
-
-	/* Ensure the relocation region coverd by a PMR */
+	/* Ensure the relocation region is coverd by a PMR */
 	movq	%rbx, %rdi
 	movl	$(_bss - startup_32), %esi
 	callq	sl_check_region
-
-	popq	%rsi
 #endif
 
 /*
@@ -484,7 +480,7 @@ SYM_FUNC_START_LOCAL_NOALIGN(.Lrelocated)
 	movq	%r15, %rdi
 	callq	sl_main
 
-	/* Ensure the decompression location is coverd by a PMR */
+	/* Ensure the decompression location is covered by a PMR */
 	movq	%rbp, %rdi
 	movq	output_len(%rip), %rsi
 	callq	sl_check_region

--- a/drivers/firmware/efi/libstub/x86-stub.c
+++ b/drivers/firmware/efi/libstub/x86-stub.c
@@ -983,8 +983,10 @@ void __noreturn efi_stub_entry(efi_handle_t handle,
 		goto fail;
 	}
 
+#if (IS_ENABLED(CONFIG_SECURE_LAUNCH))
 	/* If a Secure Launch is in progress, this never returns */
 	efi_secure_launch(boot_params);
+#endif
 
 	/*
 	 * Call the SEV init code while still running with the firmware's


### PR DESCRIPTION
Changes from LKML feedback:
 - Kconfig: Remove default no and make SL depend on TPM driver
 - Remove push/pop of %rsi since boot params are now saved in %r15
 - Minor documentation changes
 - Use SL config to optionally build out call to SL UEFI launch