### PR TITLE
Changes for booting from upstream GRUB 2.12 with PE entry support

### DIFF
--- a/arch/x86/boot/compressed/sl_stub.S
+++ b/arch/x86/boot/compressed/sl_stub.S
@@ -220,6 +220,7 @@ SYM_FUNC_END(sl_find_mle_base)
 SYM_FUNC_START(sl_check_buffer_mle_overlap)
 	/* %ecx: buffer begin %edx: buffer end */
 	/* %ebx: MLE begin %edi: MLE end */
+	/* %eax: region may be inside MLE */
 
 	cmpl	%edi, %ecx
 	jb	.Lnext_check
@@ -229,10 +230,19 @@ SYM_FUNC_START(sl_check_buffer_mle_overlap)
 
 .Lnext_check:
 	cmpl	%ebx, %edx
-	ja	.Linvalid
+	ja	.Linside_check
 	cmpl	%ebx, %ecx
-	jae	.Linvalid
+	jae	.Linside_check
 	jmp	.Lvalid /* Buffer below MLE */
+
+.Linside_check:
+	cmpl	$0, %eax
+	jz	.Linvalid
+	cmpl	%ebx, %ecx
+	jb	.Linvalid
+	cmpl	%edi, %edx
+	ja	.Linvalid
+	jmp	.Lvalid /* Buffer in MLE */
 
 .Linvalid:
 	TXT_RESET $(SL_ERROR_MLE_BUFFER_OVERLAP)
@@ -272,16 +282,26 @@ SYM_FUNC_START(sl_txt_verify_os_mle_struct)
 	movl	SL_ap_wake_block_size(%eax), %edx
 	addl	%ecx, %edx
 	jc	.Loverflow_detected
+	pushl	%eax
+	xorl	%eax, %eax
 	call	sl_check_buffer_mle_overlap
+	popl	%eax
 	cmpl	%esi, %edx
 	ja	.Lbuffer_beyond_pmr
 
-	/* Check the boot params */
+	/*
+	 * Check the boot params. Note during a UEFI boot, the boot
+	 * params will be inside the MLE image. Test for this case
+	 * in the overlap case.
+	 */
 	movl	SL_boot_params_addr(%eax), %ecx
 	movl	$(PAGE_SIZE), %edx
 	addl	%ecx, %edx
 	jc	.Loverflow_detected
+	pushl	%eax
+	movl	$1, %eax
 	call	sl_check_buffer_mle_overlap
+	popl	%eax
 	cmpl	%esi, %edx
 	ja	.Lbuffer_beyond_pmr
 

--- a/include/linux/slr_table.h
+++ b/include/linux/slr_table.h
@@ -166,6 +166,7 @@ struct slr_txt_mtrr_state {
 struct slr_entry_intel_info {
 	struct slr_entry_hdr hdr;
 	u16 reserved[2];
+	u64 txt_heap;
 	u64 saved_misc_enable_msr;
 	struct slr_txt_mtrr_state saved_bsp_mtrrs;
 } __packed;


### PR DESCRIPTION
The GRUB patches are all rebased on GRUB 2.12. The EFI stub boot support in this version uses the PE entry point and things are quite different booting via this path.