### PR TITLE
TPM use default locality instead of preferred locality

### DIFF
--- a/arch/x86/kernel/slmodule.c
+++ b/arch/x86/kernel/slmodule.c
@@ -470,7 +470,7 @@ static void slaunch_pcr_extend(void __iomem *txt)
 		slaunch_txt_reset(txt, "Could not get default TPM chip\n",
 				  SL_ERROR_TPM_INIT);
 
-	if (!tpm_preferred_locality(tpm, 2))
+	if (!tpm_chip_set_default_locality(tpm, 2))
 		slaunch_txt_reset(txt, "Could not set TPM chip locality 2\n",
 				  SL_ERROR_TPM_INIT);
 
@@ -479,7 +479,7 @@ static void slaunch_pcr_extend(void __iomem *txt)
 	else
 		slaunch_tpm12_extend(tpm, txt);
 
-	tpm_preferred_locality(tpm, 0);
+	tpm_chip_set_default_locality(tpm, 0);
 }
 
 static int __init slaunch_module_init(void)

--- a/drivers/char/tpm/tpm-chip.c
+++ b/drivers/char/tpm/tpm-chip.c
@@ -44,7 +44,7 @@ static int tpm_request_locality(struct tpm_chip *chip)
 	if (!chip->ops->request_locality)
 		return 0;
 
-	rc = chip->ops->request_locality(chip, chip->pref_locality);
+	rc = chip->ops->request_locality(chip, chip->default_locality);
 	if (rc < 0)
 		return rc;
 
@@ -144,25 +144,25 @@ void tpm_chip_stop(struct tpm_chip *chip)
 EXPORT_SYMBOL_GPL(tpm_chip_stop);
 
 /**
- * tpm_chip_preferred_locality() - set the TPM chip preferred locality to open
+ * tpm_chip_set_default_locality() - set the TPM chip default locality to open
  * @chip:	a TPM chip to use
- * @locality:   the preferred locality
+ * @locality:   the default locality to set
  *
  * Return:
  * * true      - Preferred locality set
  * * false     - Invalid locality specified
  */
-bool tpm_chip_preferred_locality(struct tpm_chip *chip, int locality)
+bool tpm_chip_set_default_locality(struct tpm_chip *chip, int locality)
 {
 	if (locality < 0 || locality >=TPM_MAX_LOCALITY)
 		return false;
 
 	mutex_lock(&chip->tpm_mutex);
-	chip->pref_locality = locality;
+	chip->default_locality = locality;
 	mutex_unlock(&chip->tpm_mutex);
 	return true;
 }
-EXPORT_SYMBOL_GPL(tpm_chip_preferred_locality);
+EXPORT_SYMBOL_GPL(tpm_chip_set_default_locality);
 
 /**
  * tpm_try_get_ops() - Get a ref to the tpm_chip
@@ -389,7 +389,7 @@ struct tpm_chip *tpm_chip_alloc(struct device *pdev,
 	}
 
 	chip->locality = -1;
-	chip->pref_locality = 0;
+	chip->default_locality = 0;
 	return chip;
 
 out:

--- a/drivers/char/tpm/tpm-interface.c
+++ b/drivers/char/tpm/tpm-interface.c
@@ -274,21 +274,6 @@ int tpm_is_tpm2(struct tpm_chip *chip)
 EXPORT_SYMBOL_GPL(tpm_is_tpm2);
 
 /**
- * tpm_preferred_locality() - set the TPM chip preferred locality to open
- * @chip:	a TPM chip to use
- * @locality:   the preferred locality
- *
- * Return:
- * * true      - Preferred locality set
- * * false     - Invalid locality specified
- */
-bool tpm_preferred_locality(struct tpm_chip *chip, int locality)
-{
-	return tpm_chip_preferred_locality(chip, locality);
-}
-EXPORT_SYMBOL_GPL(tpm_preferred_locality);
-
-/**
  * tpm_pcr_read - read a PCR value from SHA1 bank
  * @chip:	a &struct tpm_chip instance, %NULL for the default chip
  * @pcr_idx:	the PCR to be retrieved

--- a/drivers/char/tpm/tpm-sysfs.c
+++ b/drivers/char/tpm/tpm-sysfs.c
@@ -309,16 +309,16 @@ static ssize_t tpm_version_major_show(struct device *dev,
 }
 static DEVICE_ATTR_RO(tpm_version_major);
 
-static ssize_t preferred_locality_show(struct device *dev,
-				       struct device_attribute *attr, char *buf)
+static ssize_t default_locality_show(struct device *dev,
+				     struct device_attribute *attr, char *buf)
 {
 	struct tpm_chip *chip = to_tpm_chip(dev);
 
-	return sprintf(buf, "%d\n", chip->pref_locality);
+	return sprintf(buf, "%d\n", chip->default_locality);
 }
 
-static ssize_t preferred_locality_store(struct device *dev, struct device_attribute *attr,
-					const char *buf, size_t count)
+static ssize_t default_locality_store(struct device *dev, struct device_attribute *attr,
+				      const char *buf, size_t count)
 {
 	struct tpm_chip *chip = to_tpm_chip(dev);
 	unsigned int locality;
@@ -329,13 +329,13 @@ static ssize_t preferred_locality_store(struct device *dev, struct device_attrib
 	if (locality >= TPM_MAX_LOCALITY)
 		return -ERANGE;
 
-	if (tpm_chip_preferred_locality(chip, (int)locality))
+	if (tpm_chip_set_default_locality(chip, (int)locality))
 		return count;
 	else
 		return 0;
 }
 
-static DEVICE_ATTR_RW(preferred_locality);
+static DEVICE_ATTR_RW(default_locality);
 
 static struct attribute *tpm1_dev_attrs[] = {
 	&dev_attr_pubek.attr,
@@ -349,13 +349,13 @@ static struct attribute *tpm1_dev_attrs[] = {
 	&dev_attr_durations.attr,
 	&dev_attr_timeouts.attr,
 	&dev_attr_tpm_version_major.attr,
-	&dev_attr_preferred_locality.attr,
+	&dev_attr_default_locality.attr,
 	NULL,
 };
 
 static struct attribute *tpm2_dev_attrs[] = {
 	&dev_attr_tpm_version_major.attr,
-	&dev_attr_preferred_locality.attr,
+	&dev_attr_default_locality.attr,
 	NULL
 };
 

--- a/drivers/char/tpm/tpm.h
+++ b/drivers/char/tpm/tpm.h
@@ -267,7 +267,6 @@ static inline void tpm_msleep(unsigned int delay_msec)
 int tpm_chip_bootstrap(struct tpm_chip *chip);
 int tpm_chip_start(struct tpm_chip *chip);
 void tpm_chip_stop(struct tpm_chip *chip);
-bool tpm_chip_preferred_locality(struct tpm_chip *chip, int locality);
 struct tpm_chip *tpm_find_get_ops(struct tpm_chip *chip);
 
 struct tpm_chip *tpm_chip_alloc(struct device *dev,

--- a/include/linux/tpm.h
+++ b/include/linux/tpm.h
@@ -178,7 +178,7 @@ struct tpm_chip {
 	int locality;
 
 	/* preferred locality - default 0 */
-	int pref_locality;
+	int default_locality;
 };
 
 #define TPM_HEADER_SIZE		10
@@ -430,9 +430,9 @@ static inline u32 tpm2_rc_value(u32 rc)
 #if defined(CONFIG_TCG_TPM) || defined(CONFIG_TCG_TPM_MODULE)
 
 extern int tpm_is_tpm2(struct tpm_chip *chip);
-extern bool tpm_preferred_locality(struct tpm_chip *chip, int locality);
 extern __must_check int tpm_try_get_ops(struct tpm_chip *chip);
 extern void tpm_put_ops(struct tpm_chip *chip);
+extern bool tpm_chip_set_default_locality(struct tpm_chip *chip, int locality);
 extern ssize_t tpm_transmit_cmd(struct tpm_chip *chip, struct tpm_buf *buf,
 				size_t min_rsp_body_length, const char *desc);
 extern int tpm_pcr_read(struct tpm_chip *chip, u32 pcr_idx,


### PR DESCRIPTION
Per the v9 feedback, use default locality and remove unneeded TPM interface wrapper for setting it