### PR TITLE
arch/x86/kernel/slmodule.c: fix slaunch_tpm2_extend_event()

### DIFF
--- a/arch/x86/kernel/slmodule.c
+++ b/arch/x86/kernel/slmodule.c
@@ -338,18 +338,25 @@ static void slaunch_tpm2_extend_event(struct tpm_chip *tpm, void __iomem *txt,
 			case TPM_ALG_SHA256:
 				memcpy(&digests[j].digest[0], dptr,
 				       SHA256_DIGEST_SIZE);
-				alg_id_field = (u16 *)((u8 *)alg_id_field +
-					SHA256_DIGEST_SIZE + sizeof(u16));
 				break;
 			case TPM_ALG_SHA1:
 				memcpy(&digests[j].digest[0], dptr,
 				       SHA1_DIGEST_SIZE);
-				alg_id_field = (u16 *)((u8 *)alg_id_field +
-					SHA1_DIGEST_SIZE + sizeof(u16));
 				break;
 			default:
 				break;
 			}
+		}
+
+		switch (*alg_id_field) {
+		case TPM_ALG_SHA256:
+			alg_id_field = (u16 *)((u8 *)alg_id_field +
+				sizeof(u16) + SHA256_DIGEST_SIZE);
+			break;
+		case TPM_ALG_SHA1:
+			alg_id_field = (u16 *)((u8 *)alg_id_field +
+				sizeof(u16) + SHA1_DIGEST_SIZE);
+			break;
 		}
 	}
 


### PR DESCRIPTION
When the inner for loop doesn't break upon finding a matching algorithm, it:
 - finds SHA1 ID and updates `alg_id_field` but not `dptr`
 - finds SHA256 ID and copies SHA1 and bytes that follow it as SHA256
 - exits and outer loop gets to run again with `alg_id_field` pointing past the list of digests, this time likely doing nothing, leading to a PCR being extended with a semi-random hash

Breaking isn't enough on its own because then alg_id_field might end up not being moved if corresponding TPM bank is off, so instead advance the pointer outside of the inner loop.