### PR TITLE
[revision] for {7cba4600c37f3e3d04c6e8ce8267623467cfdb20}

### DIFF
--- a/arch/x86/kernel/slmodule.c
+++ b/arch/x86/kernel/slmodule.c
@@ -391,12 +391,17 @@ static void slaunch_tpm2_extend(struct tpm_chip *tpm, void __iomem *txt)
 
 		/*
 		 * Marker events indicate where the Secure Launch early stub
-		 * started and ended adding post launch events.
+		 * started and ended adding post launch events. As they are
+		 * encountered, switch the event type to NO_ACTION so they
+		 * ignored in when the event log is processed since they are
+		 * not really measurements.
 		 */
 		if (event->event_type == TXT_EVTYPE_SLAUNCH_END) {
+			event->event_type = NO_ACTION;
 			end = 1;
 			break;
 		} else if (event->event_type == TXT_EVTYPE_SLAUNCH_START) {
+			event->event_type = NO_ACTION;
 			start = 1;
 			goto next;
 		}
@@ -429,13 +434,15 @@ static void slaunch_tpm_extend(struct tpm_chip *tpm, void __iomem *txt)
 		size = sizeof(*event) + event->event_size;
 
 		/*
-		 * Marker events indicate where the Secure Launch early stub
-		 * started and ended adding post launch events.
+		 * See comments in slaunch_tpm2_extend() concerning these special
+		 * event types.
 		 */
 		if (event->event_type == TXT_EVTYPE_SLAUNCH_END) {
+			event->event_type = NO_ACTION;
 			end = 1;
 			break;
 		} else if (event->event_type == TXT_EVTYPE_SLAUNCH_START) {
+			event->event_type = NO_ACTION;
 			start = 1;
 			goto next;
 		}


### PR DESCRIPTION
Switch the vendor specific event types for the begin and end tagging events to NO_ACTION.