### PR TITLE
Move boot_params_addr field

### DIFF
--- a/arch/x86/boot/compressed/sl_main.c
+++ b/arch/x86/boot/compressed/sl_main.c
@@ -422,6 +422,7 @@ static void sl_extend_slrt(struct slr_policy_entry *entry)
 {
 	struct slr_table *slrt = (struct slr_table *)entry->entity;
 	struct slr_entry_intel_info *intel_info;
+	struct slr_entry_intel_info intel_tmp;
 
 	/*
 	 * In revision one of the SLRT, the only table that needs to be
@@ -435,8 +436,16 @@ static void sl_extend_slrt(struct slr_policy_entry *entry)
 		if (!intel_info)
 			sl_txt_reset(SL_ERROR_SLRT_MISSING_ENTRY);
 
+		/*
+		 * Make a temp copy and zero out address fields since they should
+		 * not be measured.
+		 */
+		intel_tmp = *intel_info;
+		intel_tmp.boot_params_addr = 0;
+		intel_tmp.txt_heap = 0;
+
 		sl_tpm_extend_evtlog(entry->pcr, TXT_EVTYPE_SLAUNCH,
-				     (void *)entry->entity, sizeof(*intel_info),
+				     (void *)&intel_tmp, sizeof(*intel_info),
 				     entry->evt_info);
 	}
 }

--- a/arch/x86/boot/compressed/sl_stub.S
+++ b/arch/x86/boot/compressed/sl_stub.S
@@ -132,8 +132,7 @@ SYM_FUNC_START(sl_stub_entry)
 	movl	$0, (TXT_PRIV_CONFIG_REGS_BASE + TXT_CR_ERRORCODE)
 	movl	$0xffffffff, (TXT_PRIV_CONFIG_REGS_BASE + TXT_CR_ESTS)
 
-	/* On Intel, the zero page address is passed in the TXT heap */
-	/* Read physical base of heap into EAX */
+	/* Read physical base of the TXT heap into %eax */
 	movl	(TXT_PRIV_CONFIG_REGS_BASE + TXT_CR_HEAP_BASE), %eax
 	/* Read the size of the BIOS data into ECX (first 8 bytes) */
 	movl	(%eax), %ecx
@@ -144,10 +143,11 @@ SYM_FUNC_START(sl_stub_entry)
 	call	sl_txt_verify_os_mle_struct
 
 	/*
-	 * Get the boot params address from the heap. Note %esi and %ebx MUST
-	 * be preserved across calls and operations.
+	 * Get the boot params address from the TXT info table in the SLRT.
+	 * Note %esi and %ebx MUST be preserved across calls and operations.
 	 */
-	movl	SL_boot_params_addr(%eax), %esi
+	movl	SL_txt_info(%eax), %edi
+	movl	SL_boot_params_addr(%edi), %esi
 
 	/* Save %ebx so the APs can find their way home */
 	movl	%ebx, (SL_mle_scratch + SL_SCRATCH_AP_EBX)(%eax)

--- a/arch/x86/kernel/asm-offsets.c
+++ b/arch/x86/kernel/asm-offsets.c
@@ -126,9 +126,9 @@ static void __used common(void)
 	BLANK();
 	OFFSET(SL_txt_info, txt_os_mle_data, txt_info);
 	OFFSET(SL_mle_scratch, txt_os_mle_data, mle_scratch);
-	OFFSET(SL_boot_params_addr, txt_os_mle_data, boot_params_addr);
 	OFFSET(SL_ap_wake_block, txt_os_mle_data, ap_wake_block);
 	OFFSET(SL_ap_wake_block_size, txt_os_mle_data, ap_wake_block_size);
+	OFFSET(SL_boot_params_addr, slr_entry_intel_info, boot_params_addr);
 	OFFSET(SL_saved_misc_enable_msr, slr_entry_intel_info, saved_misc_enable_msr);
 	OFFSET(SL_saved_bsp_mtrrs, slr_entry_intel_info, saved_bsp_mtrrs);
 	OFFSET(SL_num_logical_procs, txt_bios_data, num_logical_procs);

--- a/drivers/firmware/efi/libstub/x86-stub.c
+++ b/drivers/firmware/efi/libstub/x86-stub.c
@@ -931,7 +931,6 @@ static bool efi_secure_launch_update_boot_params(struct slr_table *slrt,
 {
 	struct slr_entry_intel_info *txt_info;
 	struct slr_entry_policy *policy;
-	struct txt_os_mle_data *os_mle;
 	bool updated = false;
 	int i;
 
@@ -939,11 +938,7 @@ static bool efi_secure_launch_update_boot_params(struct slr_table *slrt,
 	if (!txt_info)
 		return false;
 
-	os_mle = txt_os_mle_data_start((void *)txt_info->txt_heap);
-	if (!os_mle)
-		return false;
-
-	os_mle->boot_params_addr = (u64)boot_params;
+	txt_info->boot_params_addr = (u64)boot_params;
 
 	policy = slr_next_entry_by_tag(slrt, NULL, SLR_ENTRY_ENTRY_POLICY);
 	if (!policy)

--- a/include/linux/slaunch.h
+++ b/include/linux/slaunch.h
@@ -232,7 +232,6 @@ struct txt_heap_event_log_pointer2_1_element {
 struct txt_os_mle_data {
 	u32 version;
 	u32 reserved;
-	u64 boot_params_addr;
 	u64 slrt;
 	u64 txt_info;
 	u32 ap_wake_block;

--- a/include/linux/slr_table.h
+++ b/include/linux/slr_table.h
@@ -171,6 +171,7 @@ struct slr_txt_mtrr_state {
  */
 struct slr_entry_intel_info {
 	struct slr_entry_hdr hdr;
+	u64 boot_params_addr;
 	u64 txt_heap;
 	u64 saved_misc_enable_msr;
 	struct slr_txt_mtrr_state saved_bsp_mtrrs;


### PR DESCRIPTION
Move the boot_params_addr field out of the OS-MLE TXT heap table into the Intel info table in the SLRT.