### PR TITLE
Remove UNICODE chars from text

### DIFF
--- a/Documentation/security/launch-integrity/principles.rst
+++ b/Documentation/security/launch-integrity/principles.rst
@@ -1,5 +1,5 @@
 .. SPDX-License-Identifier: GPL-2.0
-.. Copyright © 2019-2024 Daniel P. Smith <dpsmith@apertussolutions.com>
+.. Copyright (c) 2019-2024 Daniel P. Smith <dpsmith@apertussolutions.com>
 
 =======================
 System Launch Integrity
@@ -63,7 +63,7 @@ late launch.
    launch chain to the final Operating System.
 
 :Late Launch: The usage of a dynamic launch by an executing Operating System to
-   transition to a “known good” state to perform one or more operations, e.g. to
+   transition to a "known good" state to perform one or more operations, e.g. to
    launch into a new Operating System.
 
 System Integrity

--- a/Documentation/security/launch-integrity/secure_launch_details.rst
+++ b/Documentation/security/launch-integrity/secure_launch_details.rst
@@ -1,5 +1,5 @@
 .. SPDX-License-Identifier: GPL-2.0
-.. Copyright © 2019-2024 Daniel P. Smith <dpsmith@apertussolutions.com>
+.. Copyright (c) 2019-2024 Daniel P. Smith <dpsmith@apertussolutions.com>
 
 ===================================
 Secure Launch Config and Interfaces

--- a/Documentation/security/launch-integrity/secure_launch_overview.rst
+++ b/Documentation/security/launch-integrity/secure_launch_overview.rst
@@ -1,5 +1,5 @@
 .. SPDX-License-Identifier: GPL-2.0
-.. Copyright © 2019-2024 Daniel P. Smith <dpsmith@apertussolutions.com>
+.. Copyright (c) 2019-2024 Daniel P. Smith <dpsmith@apertussolutions.com>
 
 ======================
 Secure Launch Overview

--- a/include/linux/slaunch.h
+++ b/include/linux/slaunch.h
@@ -29,11 +29,11 @@
  * Intel SMX provides a programming interface to establish a Measured Launched
  * Environment (MLE). The measurement and protection mechanisms supported by the
  * capabilities of an Intel Trusted Execution Technology (TXT) platform. SMX is
- * the processor’s programming interface in an Intel TXT platform.
+ * the processor's programming interface in an Intel TXT platform.
  *
  * See:
  *   Intel SDM Volume 2 - 6.1 "Safer Mode Extensions Reference"
- *   Intel Trusted Execution Technology - Measured Launch Environment Developer’s Guide
+ *   Intel Trusted Execution Technology - Measured Launch Environment Developer's Guide
  */
 
 /*


### PR DESCRIPTION
Keep the patches entirely ASCII to prevent encodings during patch set creation.