### PR TITLE
Split Secure Launch and TXT headers

### DIFF
--- a/arch/x86/boot/compressed/sl_main.c
+++ b/arch/x86/boot/compressed/sl_main.c
@@ -210,7 +210,7 @@ static void sl_find_drtm_event_log(struct slr_table *slrt)
 		sl_txt_reset(SL_ERROR_OS_SINIT_BAD_VERSION);
 
 	/* Find the TPM2.0 logging extended heap element */
-	log21_elem = tpm2_find_log2_1_element(os_sinit_data);
+	log21_elem = txt_find_log2_1_element(os_sinit_data);
 
 	/* If found, this implies TPM2 log and family */
 	if (log21_elem)
@@ -405,7 +405,7 @@ static struct setup_data *sl_handle_setup_data(struct setup_data *curr,
 
 		sl_check_pmr_coverage((void *)ind->addr, ind->len, true);
 
-		sl_tpm_extend(entry->pcr, TXT_EVTYPE_SLAUNCH, (void *)ind->addr, ind->len,
+		sl_tpm_extend(entry->pcr, SL_EVTYPE_SECURE_LAUNCH, (void *)ind->addr, ind->len,
 			      entry->evt_info);
 
 		return next;
@@ -414,7 +414,7 @@ static struct setup_data *sl_handle_setup_data(struct setup_data *curr,
 	sl_check_pmr_coverage(((u8 *)curr) + sizeof(*curr),
 			      curr->len, true);
 
-	sl_tpm_extend(entry->pcr, TXT_EVTYPE_SLAUNCH, ((u8 *)curr) + sizeof(*curr), curr->len,
+	sl_tpm_extend(entry->pcr, SL_EVTYPE_SECURE_LAUNCH, ((u8 *)curr) + sizeof(*curr), curr->len,
 		      entry->evt_info);
 
 	return next;
@@ -459,7 +459,7 @@ static void sl_extend_slrt(struct slr_policy_entry *entry)
 		intel_tmp.boot_params_addr = 0;
 		intel_tmp.txt_heap = 0;
 
-		sl_tpm_extend(entry->pcr, TXT_EVTYPE_SLAUNCH, (void *)&intel_tmp,
+		sl_tpm_extend(entry->pcr, SL_EVTYPE_SECURE_LAUNCH, (void *)&intel_tmp,
 			      sizeof(*intel_info), entry->evt_info);
 	}
 }
@@ -506,7 +506,7 @@ static void sl_process_extend_policy(struct slr_table *slrt)
 		case SLR_ET_UNUSED:
 			continue;
 		default:
-			sl_tpm_extend(policy->policy_entries[i].pcr, TXT_EVTYPE_SLAUNCH,
+			sl_tpm_extend(policy->policy_entries[i].pcr, SL_EVTYPE_SECURE_LAUNCH,
 				      (void *)policy->policy_entries[i].entity,
 				      policy->policy_entries[i].size,
 				      policy->policy_entries[i].evt_info);
@@ -529,7 +529,7 @@ static void sl_process_extend_uefi_config(struct slr_table *slrt)
 		return;
 
 	for (i = 0; i < uefi_config->nr_entries; i++) {
-		sl_tpm_extend(uefi_config->uefi_cfg_entries[i].pcr, TXT_EVTYPE_SLAUNCH,
+		sl_tpm_extend(uefi_config->uefi_cfg_entries[i].pcr, SL_EVTYPE_SECURE_LAUNCH,
 			      (void *)uefi_config->uefi_cfg_entries[i].cfg,
 			      uefi_config->uefi_cfg_entries[i].size,
 			      uefi_config->uefi_cfg_entries[i].evt_info);

--- a/arch/x86/boot/compressed/sl_stub.S
+++ b/arch/x86/boot/compressed/sl_stub.S
@@ -374,7 +374,7 @@ SYM_FUNC_START(sl_txt_ap_entry)
 	movw	%dx, %ss
 
 	/* Load our reloc AP stack */
-	movl	$(TXT_BOOT_STACK_SIZE), %edx
+	movl	$(SL_BOOT_STACK_SIZE), %edx
 	mull	%edx
 	leal	(sl_stacks_end - sl_txt_ap_wake_begin)(%ecx), %esp
 	subl	%eax, %esp
@@ -611,7 +611,7 @@ sl_txt_ap_wake_begin:
 	 * ID value.
 	 */
 	movl	%esp, %edi
-	subl	$(TXT_BOOT_STACK_SIZE - 4), %edi
+	subl	$(SL_BOOT_STACK_SIZE - 4), %edi
 	movl	$0, (%edi)
 
 1:
@@ -689,7 +689,7 @@ SYM_DATA_END_LABEL(sl_ap_gdt, SYM_L_LOCAL, sl_ap_gdt_end)
 	/* Small stacks for BSP and APs to work with */
 	.balign 64
 SYM_DATA_START_LOCAL(sl_stacks)
-	.fill (TXT_MAX_CPUS * TXT_BOOT_STACK_SIZE), 1, 0
+	.fill (SL_MAX_CPUS * SL_BOOT_STACK_SIZE), 1, 0
 SYM_DATA_END_LABEL(sl_stacks, SYM_L_LOCAL, sl_stacks_end)
 
 /* This is the end of the relocated AP wake code block */

--- a/arch/x86/include/asm/txt.h
+++ b/arch/x86/include/asm/txt.h
@@ -1,0 +1,331 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+/*
+ * Intel Trusted eXecution Technology (TXT) Definitions
+ *
+ * Copyright (c) 2025 Apertus Solutions, LLC
+ * Copyright (c) 2025, Oracle and/or its affiliates.
+ */
+
+#ifndef _ASM_X86_TXT_H
+#define _ASM_X86_TXT_H
+
+/*
+ * Intel Safer Mode Extensions (SMX)
+ *
+ * Intel SMX provides a programming interface to establish a Measured Launched
+ * Environment (MLE). The measurement and protection mechanisms supported by the
+ * capabilities of an Intel Trusted Execution Technology (TXT) platform. SMX is
+ * the processor's programming interface in an Intel TXT platform.
+ *
+ * See:
+ *   Intel SDM Volume 2 - 6.1 "Safer Mode Extensions Reference"
+ *   Intel Trusted Execution Technology - Measured Launch Environment Developer's Guide
+ */
+
+/*
+ * SMX GETSEC Leaf Functions
+ */
+#define SMX_X86_GETSEC_SEXIT	5
+#define SMX_X86_GETSEC_SMCTRL	7
+#define SMX_X86_GETSEC_WAKEUP	8
+
+/*
+ * Intel Trusted Execution Technology MMIO Registers Banks
+ */
+#define TXT_PUB_CONFIG_REGS_BASE	0xfed30000
+#define TXT_PRIV_CONFIG_REGS_BASE	0xfed20000
+#define TXT_NR_CONFIG_PAGES     ((TXT_PUB_CONFIG_REGS_BASE - \
+				  TXT_PRIV_CONFIG_REGS_BASE) >> PAGE_SHIFT)
+
+/*
+ * Intel Trusted Execution Technology (TXT) Registers
+ */
+#define TXT_CR_STS			0x0000
+#define TXT_CR_ESTS			0x0008
+#define TXT_CR_ERRORCODE		0x0030
+#define TXT_CR_CMD_RESET		0x0038
+#define TXT_CR_CMD_CLOSE_PRIVATE	0x0048
+#define TXT_CR_DIDVID			0x0110
+#define TXT_CR_VER_EMIF			0x0200
+#define TXT_CR_CMD_UNLOCK_MEM_CONFIG	0x0218
+#define TXT_CR_SINIT_BASE		0x0270
+#define TXT_CR_SINIT_SIZE		0x0278
+#define TXT_CR_MLE_JOIN			0x0290
+#define TXT_CR_HEAP_BASE		0x0300
+#define TXT_CR_HEAP_SIZE		0x0308
+#define TXT_CR_SCRATCHPAD		0x0378
+#define TXT_CR_CMD_OPEN_LOCALITY1	0x0380
+#define TXT_CR_CMD_CLOSE_LOCALITY1	0x0388
+#define TXT_CR_CMD_OPEN_LOCALITY2	0x0390
+#define TXT_CR_CMD_CLOSE_LOCALITY2	0x0398
+#define TXT_CR_CMD_SECRETS		0x08e0
+#define TXT_CR_CMD_NO_SECRETS		0x08e8
+#define TXT_CR_E2STS			0x08f0
+
+/* TXT default register value */
+#define TXT_REGVALUE_ONE		0x1ULL
+
+/* TXTCR_STS status bits */
+#define TXT_SENTER_DONE_STS		BIT(0)
+#define TXT_SEXIT_DONE_STS		BIT(1)
+
+/*
+ * SINIT/MLE Capabilities Field Bit Definitions
+ */
+#define TXT_SINIT_MLE_CAP_WAKE_GETSEC	0
+#define TXT_SINIT_MLE_CAP_WAKE_MONITOR	1
+
+/*
+ * OS/MLE Secure Launch Specific Definitions
+ */
+#define TXT_OS_MLE_STRUCT_VERSION	1
+#define TXT_OS_MLE_MAX_VARIABLE_MTRRS	32
+
+/*
+ * TXT Heap Table Enumeration
+ */
+#define TXT_BIOS_DATA_TABLE		1
+#define TXT_OS_MLE_DATA_TABLE		2
+#define TXT_OS_SINIT_DATA_TABLE		3
+#define TXT_SINIT_MLE_DATA_TABLE	4
+#define TXT_SINIT_TABLE_MAX		TXT_SINIT_MLE_DATA_TABLE
+
+#ifndef __ASSEMBLER__
+
+/*
+ * TXT heap extended data elements.
+ */
+struct txt_heap_ext_data_element {
+	u32 type;
+	u32 size;
+	/* Data */
+} __packed;
+
+#define TXT_HEAP_EXTDATA_TYPE_END			0
+
+struct txt_heap_end_element {
+	u32 type;
+	u32 size;
+} __packed;
+
+#define TXT_HEAP_EXTDATA_TYPE_TPM_EVENT_LOG_PTR		5
+
+struct txt_heap_event_log_element {
+	u64 event_log_phys_addr;
+} __packed;
+
+#define TXT_HEAP_EXTDATA_TYPE_EVENT_LOG_POINTER2_1	8
+
+struct txt_heap_event_log_pointer2_1_element {
+	u64 phys_addr;
+	u32 allocated_event_container_size;
+	u32 first_record_offset;
+	u32 next_record_offset;
+} __packed;
+
+/*
+ * TXT specification defined BIOS data TXT Heap table
+ */
+struct txt_bios_data {
+	u32 version; /* Currently 5 for TPM 1.2 and 6 for TPM 2.0 */
+	u32 bios_sinit_size;
+	u64 reserved1;
+	u64 reserved2;
+	u32 num_logical_procs;
+	/* Versions >= 5 with updates in version 6 */
+	u32 sinit_flags;
+	u32 mle_flags;
+	/* Versions >= 4 */
+	/* Ext Data Elements */
+} __packed;
+
+/*
+ * TXT specification defined OS/SINIT TXT Heap table
+ */
+struct txt_os_sinit_data {
+	u32 version; /* Currently 6 for TPM 1.2 and 7 for TPM 2.0 */
+	u32 flags;
+	u64 mle_ptab;
+	u64 mle_size;
+	u64 mle_hdr_base;
+	u64 vtd_pmr_lo_base;
+	u64 vtd_pmr_lo_size;
+	u64 vtd_pmr_hi_base;
+	u64 vtd_pmr_hi_size;
+	u64 lcp_po_base;
+	u64 lcp_po_size;
+	u32 capabilities;
+	/* Version = 5 */
+	u64 efi_rsdt_ptr;
+	/* Versions >= 6 */
+	/* Ext Data Elements */
+} __packed;
+
+/*
+ * TXT specification defined SINIT/MLE TXT Heap table
+ */
+struct txt_sinit_mle_data {
+	u32 version;             /* Current values are 6 through 9 */
+	/* Versions <= 8 */
+	u8 bios_acm_id[20];
+	u32 edx_senter_flags;
+	u64 mseg_valid;
+	u8 sinit_hash[20];
+	u8 mle_hash[20];
+	u8 stm_hash[20];
+	u8 lcp_policy_hash[20];
+	u32 lcp_policy_control;
+	/* Versions >= 7 */
+	u32 rlp_wakeup_addr;
+	u32 reserved;
+	u32 num_of_sinit_mdrs;
+	u32 sinit_mdrs_table_offset;
+	u32 sinit_vtd_dmar_table_size;
+	u32 sinit_vtd_dmar_table_offset;
+	/* Versions >= 8 */
+	u32 processor_scrtm_status;
+	/* Versions >= 9 */
+	/* Ext Data Elements */
+} __packed;
+
+/*
+ * TXT data reporting structure for memory types
+ */
+struct txt_sinit_memory_descriptor_record {
+	u64 address;
+	u64 length;
+	u8 type;
+	u8 reserved[7];
+} __packed;
+
+/*
+ * TXT data structure used by a responsive local processor (RLP) to start
+ * execution in response to a GETSEC[WAKEUP].
+ */
+struct smx_rlp_mle_join {
+	u32 rlp_gdt_limit;
+	u32 rlp_gdt_base;
+	u32 rlp_seg_sel;     /* cs (ds, es, ss are seg_sel+8) */
+	u32 rlp_entry_point; /* phys addr */
+} __packed;
+
+/*
+ * TPM event log structures defined in both the TXT specification and
+ * the TCG documentation.
+ */
+#define TPM_EVTLOG_SIGNATURE "TXT Event Container"
+
+struct tpm_event_log_header {
+	char signature[20];
+	char reserved[12];
+	u8 container_ver_major;
+	u8 container_ver_minor;
+	u8 pcr_event_ver_major;
+	u8 pcr_event_ver_minor;
+	u32 container_size;
+	u32 pcr_events_offset;
+	u32 next_event_offset;
+	/* PCREvents[] */
+} __packed;
+
+/*
+ * Functions to extract data from the Intel TXT Heap Memory. The layout
+ * of the heap is as follows:
+ *  +----------------------------+
+ *  | Size Bios Data table (u64) |
+ *  +----------------------------+
+ *  | Bios Data table            |
+ *  +----------------------------+
+ *  | Size OS MLE table (u64)    |
+ *  +----------------------------+
+ *  | OS MLE table               |
+ *  +--------------------------- +
+ *  | Size OS SINIT table (u64)  |
+ *  +----------------------------+
+ *  | OS SINIT table             |
+ *  +----------------------------+
+ *  | Size SINIT MLE table (u64) |
+ *  +----------------------------+
+ *  | SINIT MLE table            |
+ *  +----------------------------+
+ *
+ *  NOTE: the table size fields include the 8 byte size field itself.
+ */
+static inline u64 txt_bios_data_size(void *heap)
+{
+	return *((u64 *)heap);
+}
+
+static inline void *txt_bios_data_start(void *heap)
+{
+	return heap + sizeof(u64);
+}
+
+static inline u64 txt_os_mle_data_size(void *heap)
+{
+	return *((u64 *)(heap + txt_bios_data_size(heap)));
+}
+
+static inline void *txt_os_mle_data_start(void *heap)
+{
+	return heap + txt_bios_data_size(heap) + sizeof(u64);
+}
+
+static inline u64 txt_os_sinit_data_size(void *heap)
+{
+	return *((u64 *)(heap + txt_bios_data_size(heap) +
+			txt_os_mle_data_size(heap)));
+}
+
+static inline void *txt_os_sinit_data_start(void *heap)
+{
+	return heap + txt_bios_data_size(heap) +
+		txt_os_mle_data_size(heap) + sizeof(u64);
+}
+
+static inline u64 txt_sinit_mle_data_size(void *heap)
+{
+	return *((u64 *)(heap + txt_bios_data_size(heap) +
+			txt_os_mle_data_size(heap) +
+			txt_os_sinit_data_size(heap)));
+}
+
+static inline void *txt_sinit_mle_data_start(void *heap)
+{
+	return heap + txt_bios_data_size(heap) +
+		txt_os_mle_data_size(heap) +
+		txt_os_sinit_data_size(heap) + sizeof(u64);
+}
+
+/*
+ * Find the TPM v2 event log element in the TXT heap. This element contains
+ * the information about the size and location of the DRTM event log. Note
+ * this is a TXT specific structure.
+ *
+ * See:
+ *   Intel Trusted Execution Technology - Measured Launch Environment Developer's Guide - Appendix C.
+ */
+static inline struct txt_heap_event_log_pointer2_1_element*
+txt_find_log2_1_element(struct txt_os_sinit_data *os_sinit_data)
+{
+	struct txt_heap_ext_data_element *ext_elem;
+
+	/* The extended element array as at the end of this table */
+	ext_elem = (struct txt_heap_ext_data_element *)
+		((u8 *)os_sinit_data + sizeof(struct txt_os_sinit_data));
+
+	while (ext_elem->type != TXT_HEAP_EXTDATA_TYPE_END) {
+		if (ext_elem->type == TXT_HEAP_EXTDATA_TYPE_EVENT_LOG_POINTER2_1) {
+			return (struct txt_heap_event_log_pointer2_1_element *)
+				((u8 *)ext_elem + sizeof(struct txt_heap_ext_data_element));
+		}
+		ext_elem = (struct txt_heap_ext_data_element *)
+			    ((u8 *)ext_elem + ext_elem->size);
+	}
+
+	return NULL;
+}
+
+#endif /* !__ASSEMBLER__ */
+
+#endif /* _ASM_X86_TXT_H */

--- a/arch/x86/kernel/setup.c
+++ b/arch/x86/kernel/setup.c
@@ -1026,7 +1026,7 @@ void __init setup_arch(char **cmdline_p)
 	early_gart_iommu_check();
 #endif
 
-	slaunch_setup_txt();
+	slaunch_setup();
 
 	/*
 	 * partially used pages are not usable - thus

--- a/arch/x86/kernel/slaunch.c
+++ b/arch/x86/kernel/slaunch.c
@@ -67,8 +67,7 @@ struct acpi_table_header *slaunch_get_dmar_table(struct acpi_table_header *dmar)
  * If running within a TXT established DRTM, this is the proper way to reset
  * the system if a failure occurs or a security issue is found.
  */
-void __noreturn slaunch_txt_reset(void __iomem *txt,
-				  const char *msg, u64 error)
+static void __noreturn slaunch_txt_reset(void __iomem *txt, const char *msg, u64 error)
 {
 	u64 one = 1, val;
 
@@ -93,6 +92,21 @@ void __noreturn slaunch_txt_reset(void __iomem *txt,
 }
 
 /*
+ * Handle fatal errors during DRTM initialization.
+ */
+void __noreturn slaunch_reset(void *ctx, const char *msg, u64 error)
+{
+	if (slaunch_is_txt_launch())
+		slaunch_txt_reset(ctx, msg, error);
+
+	/* Generic handler for x86 */
+	pr_err("Secure Launch: %s - error: 0x%llx", msg, error);
+	asm volatile ("ud2");
+
+	unreachable();
+}
+
+/*
  * The TXT heap is too big to map all at once with early_ioremap
  * so it is done a table at a time.
  */
@@ -104,8 +118,7 @@ static void __init *txt_early_get_heap_table(void __iomem *txt, u32 type,
 	int i;
 
 	if (type > TXT_SINIT_TABLE_MAX)
-		slaunch_txt_reset(txt, "Error invalid table type for early heap walk\n",
-				  SL_ERROR_HEAP_WALK);
+		slaunch_reset(txt, "Error invalid table type for early heap walk\n", SL_ERROR_HEAP_WALK);
 
 	memcpy_fromio(&base, txt + TXT_CR_HEAP_BASE, sizeof(base));
 	memcpy_fromio(&size, txt + TXT_CR_HEAP_SIZE, sizeof(size));
@@ -115,8 +128,7 @@ static void __init *txt_early_get_heap_table(void __iomem *txt, u32 type,
 		base += offset;
 		heap = early_memremap(base, sizeof(u64));
 		if (!heap)
-			slaunch_txt_reset(txt, "Error early_memremap of heap for heap walk\n",
-					  SL_ERROR_HEAP_MAP);
+			slaunch_reset(txt, "Error early_memremap of heap for heap walk\n", SL_ERROR_HEAP_MAP);
 
 		offset = *((u64 *)heap);
 
@@ -125,8 +137,7 @@ static void __init *txt_early_get_heap_table(void __iomem *txt, u32 type,
 		 * implies the TXT heap is corrupted.
 		 */
 		if (!offset)
-			slaunch_txt_reset(txt, "Error invalid 0 offset in heap walk\n",
-					  SL_ERROR_HEAP_ZERO_OFFSET);
+			slaunch_reset(txt, "Error invalid 0 offset in heap walk\n", SL_ERROR_HEAP_ZERO_OFFSET);
 
 		early_memunmap(heap, sizeof(u64));
 	}
@@ -135,8 +146,7 @@ static void __init *txt_early_get_heap_table(void __iomem *txt, u32 type,
 	base += sizeof(u64);
 	heap = early_memremap(base, bytes);
 	if (!heap)
-		slaunch_txt_reset(txt, "Error early_memremap of heap section\n",
-				  SL_ERROR_HEAP_MAP);
+		slaunch_reset(txt, "Error early_memremap of heap section\n", SL_ERROR_HEAP_MAP);
 
 	return heap;
 }
@@ -213,7 +223,7 @@ out:
 	txt_early_put_heap_table(os_sinit_data, field_offset);
 
 	if (err)
-		slaunch_txt_reset(txt, errmsg, err);
+		slaunch_reset(txt, errmsg, err);
 }
 
 static void __init slaunch_txt_reserve_range(u64 base, u64 size)
@@ -338,18 +348,15 @@ static void __init slaunch_copy_dmar_table(void __iomem *txt)
 	txt_early_put_heap_table(sinit_mle_data, field_offset);
 
 	if (!dmar_size || !dmar_offset)
-		slaunch_txt_reset(txt, "Error invalid DMAR table values\n",
-				  SL_ERROR_HEAP_INVALID_DMAR);
+		slaunch_reset(txt, "Error invalid DMAR table values\n", SL_ERROR_HEAP_INVALID_DMAR);
 
 	if (unlikely(dmar_size > PAGE_SIZE))
-		slaunch_txt_reset(txt, "Error DMAR too big to store\n",
-				  SL_ERROR_HEAP_DMAR_SIZE);
+		slaunch_reset(txt, "Error DMAR too big to store\n", SL_ERROR_HEAP_DMAR_SIZE);
 
 	dmar = txt_early_get_heap_table(txt, TXT_SINIT_MLE_DATA_TABLE,
 					dmar_offset + dmar_size - 8);
 	if (!dmar)
-		slaunch_txt_reset(txt, "Error early_ioremap of DMAR\n",
-				  SL_ERROR_HEAP_DMAR_MAP);
+		slaunch_reset(txt, "Error early_ioremap of DMAR\n", SL_ERROR_HEAP_DMAR_MAP);
 
 	memcpy(txt_dmar, dmar + dmar_offset - 8, dmar_size);
 
@@ -386,22 +393,19 @@ static void __init slaunch_fetch_values(void __iomem *txt)
 
 	slrt = (struct slr_table *)early_memremap(os_mle_data->slrt, sizeof(*slrt));
 	if (!slrt)
-		slaunch_txt_reset(txt, "Error early_memremap of SLRT failed\n",
-				  SL_ERROR_SLRT_MAP);
+		slaunch_reset(txt, "Error early_memremap of SLRT failed\n", SL_ERROR_SLRT_MAP);
 
 	size = slrt->size;
 	early_memunmap(slrt, sizeof(*slrt));
 
 	slrt = (struct slr_table *)early_memremap(os_mle_data->slrt, size);
 	if (!slrt)
-		slaunch_txt_reset(txt, "Error early_memremap of SLRT failed\n",
-				  SL_ERROR_SLRT_MAP);
+		slaunch_reset(txt, "Error early_memremap of SLRT failed\n", SL_ERROR_SLRT_MAP);
 
 	log_info = slr_next_entry_by_tag(slrt, NULL, SLR_ENTRY_LOG_INFO);
 
 	if (!log_info)
-		slaunch_txt_reset(txt, "SLRT missing logging info entry\n",
-				  SL_ERROR_SLRT_MISSING_ENTRY);
+		slaunch_reset(txt, "SLRT missing logging info entry\n", SL_ERROR_SLRT_MISSING_ENTRY);
 
 	evtlog_addr = log_info->addr;
 	evtlog_size = log_info->size;
@@ -415,20 +419,10 @@ static void __init slaunch_fetch_values(void __iomem *txt)
  * Intel TXT specific late stub setup and validation called from within
  * x86 specific setup_arch().
  */
-void __init slaunch_setup_txt(void)
+static void __init slaunch_setup_txt(void)
 {
 	u64 one = TXT_REGVALUE_ONE, val;
 	void __iomem *txt;
-
-	if (!boot_cpu_has(X86_FEATURE_SMX))
-		return;
-
-	/*
-	 * If booted through secure launch entry point, the loadflags
-	 * option will be set.
-	 */
-	if (!(boot_params.hdr.loadflags & SLAUNCH_FLAG))
-		return;
 
 	/*
 	 * See if SENTER was done by reading the status register in the
@@ -501,6 +495,18 @@ void __init slaunch_setup_txt(void)
 	pr_info("Intel TXT setup complete\n");
 }
 
+void __init slaunch_setup(void)
+{
+	/*
+	 * If booted through secure launch entry point, the loadflags
+	 * option will be set.
+	 */
+	if (!(boot_params.hdr.loadflags & SLAUNCH_FLAG))
+		return;
+
+	if (boot_cpu_has(X86_FEATURE_SMX))
+		slaunch_setup_txt();
+}
 /*
  * Called to fix the long jump address for the waiting APs to vector to
  * the correct startup location in the Secure Launch stub in the rmpiggy.

--- a/arch/x86/kernel/slmodule.c
+++ b/arch/x86/kernel/slmodule.c
@@ -258,35 +258,30 @@ static void slaunch_intel_evtlog(void __iomem *txt)
 	/* now map TXT heap */
 	txt_heap = memremap(base, size, MEMREMAP_WB);
 	if (!txt_heap)
-		slaunch_txt_reset(txt, "Error failed to memremap TXT heap\n",
-				  SL_ERROR_HEAP_MAP);
+		slaunch_reset(txt, "Error failed to memremap TXT heap\n", SL_ERROR_HEAP_MAP);
 
 	params = (struct txt_os_mle_data *)txt_os_mle_data_start(txt_heap);
 
 	/* Get the SLRT and remap it */
 	slrt = memremap(params->slrt, sizeof(*slrt), MEMREMAP_WB);
 	if (!slrt)
-		slaunch_txt_reset(txt, "Error failed to memremap SLR Table\n",
-				  SL_ERROR_SLRT_MAP);
+		slaunch_reset(txt, "Error failed to memremap SLR Table\n", SL_ERROR_SLRT_MAP);
 	size = slrt->size;
 	memunmap(slrt);
 
 	slrt = memremap(params->slrt, size, MEMREMAP_WB);
 	if (!slrt)
-		slaunch_txt_reset(txt, "Error failed to memremap SLR Table\n",
-				  SL_ERROR_SLRT_MAP);
+		slaunch_reset(txt, "Error failed to memremap SLR Table\n", SL_ERROR_SLRT_MAP);
 
 	log_info = slr_next_entry_by_tag(slrt, NULL, SLR_ENTRY_LOG_INFO);
 	if (!log_info)
-		slaunch_txt_reset(txt, "Error failed to memremap SLR Table\n",
-				  SL_ERROR_SLRT_MISSING_ENTRY);
+		slaunch_reset(txt, "Error failed to memremap SLR Table\n", SL_ERROR_SLRT_MISSING_ENTRY);
 
 	sl_evtlog.size = log_info->size;
 	sl_evtlog.addr = memremap(log_info->addr, log_info->size,
 				  MEMREMAP_WB);
 	if (!sl_evtlog.addr)
-		slaunch_txt_reset(txt, "Error failed to memremap TPM event log\n",
-				  SL_ERROR_EVENTLOG_MAP);
+		slaunch_reset(txt, "Error failed to memremap TPM event log\n", SL_ERROR_EVENTLOG_MAP);
 
 	memunmap(slrt);
 
@@ -298,15 +293,14 @@ static void slaunch_intel_evtlog(void __iomem *txt)
 	/* For TPM 2.0 logs, the extended heap element must be located */
 	os_sinit_data = txt_os_sinit_data_start(txt_heap);
 
-	evtlog21 = tpm2_find_log2_1_element(os_sinit_data);
+	evtlog21 = txt_find_log2_1_element(os_sinit_data);
 
 	/*
 	 * If this fails, things are in really bad shape. Any attempt to write
 	 * events to the log will fail.
 	 */
 	if (!evtlog21)
-		slaunch_txt_reset(txt, "Error failed to find TPM20 event log element\n",
-				  SL_ERROR_TPM_INVALID_LOG20);
+		slaunch_reset(txt, "Error failed to find TPM20 event log element\n", SL_ERROR_TPM_INVALID_LOG20);
 
 	/* Save pointer to the EFI SpecID log header */
 	efi_head = (struct tcg_efi_specid_event_head *)(sl_evtlog.addr + sizeof(struct tcg_pcr_event));
@@ -319,13 +313,11 @@ static void slaunch_tpm_open_locality2(void __iomem *txt)
 
 	tpm = tpm_default_chip();
 	if (!tpm)
-		slaunch_txt_reset(txt, "Could not get default TPM chip\n",
-				  SL_ERROR_TPM_INIT);
+		slaunch_reset(txt, "Could not get default TPM chip\n", SL_ERROR_TPM_INIT);
 
 	rc = tpm_chip_set_locality(tpm, 2);
 	if (rc)
-		slaunch_txt_reset(txt, "Could not set TPM chip locality 2\n",
-				  SL_ERROR_TPM_INIT);
+		slaunch_reset(txt, "Could not set TPM chip locality 2\n", SL_ERROR_TPM_INIT);
 }
 
 static int __init slaunch_module_init(void)

--- a/arch/x86/kernel/smpboot.c
+++ b/arch/x86/kernel/smpboot.c
@@ -853,7 +853,7 @@ static void slaunch_wakeup_cpu_from_txt(int cpu, int apicid)
 	stack_monitor = (struct sl_ap_stack_and_monitor *)__va(ap_wake_info->ap_wake_block +
 							       ap_wake_info->ap_stacks_offset);
 
-	for (unsigned int i = TXT_MAX_CPUS - 1; i >= 0; i--) {
+	for (unsigned int i = SL_MAX_CPUS - 1; i >= 0; i--) {
 		if (stack_monitor[i].apicid == apicid) {
 			stack_monitor[i].monitor = 1;
 			break;

--- a/include/linux/slaunch.h
+++ b/include/linux/slaunch.h
@@ -9,6 +9,8 @@
 #ifndef _LINUX_SLAUNCH_H
 #define _LINUX_SLAUNCH_H
 
+#include <asm/txt.h>
+
 /*
  * Secure Launch Defined State Flags
  */
@@ -22,87 +24,6 @@
 
 #define __SL32_CS	0x0008
 #define __SL32_DS	0x0010
-
-/*
- * Intel Safer Mode Extensions (SMX)
- *
- * Intel SMX provides a programming interface to establish a Measured Launched
- * Environment (MLE). The measurement and protection mechanisms supported by the
- * capabilities of an Intel Trusted Execution Technology (TXT) platform. SMX is
- * the processor's programming interface in an Intel TXT platform.
- *
- * See:
- *   Intel SDM Volume 2 - 6.1 "Safer Mode Extensions Reference"
- *   Intel Trusted Execution Technology - Measured Launch Environment Developer's Guide
- */
-
-/*
- * SMX GETSEC Leaf Functions
- */
-#define SMX_X86_GETSEC_SEXIT	5
-#define SMX_X86_GETSEC_SMCTRL	7
-#define SMX_X86_GETSEC_WAKEUP	8
-
-/*
- * Intel Trusted Execution Technology MMIO Registers Banks
- */
-#define TXT_PUB_CONFIG_REGS_BASE	0xfed30000
-#define TXT_PRIV_CONFIG_REGS_BASE	0xfed20000
-#define TXT_NR_CONFIG_PAGES     ((TXT_PUB_CONFIG_REGS_BASE - \
-				  TXT_PRIV_CONFIG_REGS_BASE) >> PAGE_SHIFT)
-
-/*
- * Intel Trusted Execution Technology (TXT) Registers
- */
-#define TXT_CR_STS			0x0000
-#define TXT_CR_ESTS			0x0008
-#define TXT_CR_ERRORCODE		0x0030
-#define TXT_CR_CMD_RESET		0x0038
-#define TXT_CR_CMD_CLOSE_PRIVATE	0x0048
-#define TXT_CR_DIDVID			0x0110
-#define TXT_CR_VER_EMIF			0x0200
-#define TXT_CR_CMD_UNLOCK_MEM_CONFIG	0x0218
-#define TXT_CR_SINIT_BASE		0x0270
-#define TXT_CR_SINIT_SIZE		0x0278
-#define TXT_CR_MLE_JOIN			0x0290
-#define TXT_CR_HEAP_BASE		0x0300
-#define TXT_CR_HEAP_SIZE		0x0308
-#define TXT_CR_SCRATCHPAD		0x0378
-#define TXT_CR_CMD_OPEN_LOCALITY1	0x0380
-#define TXT_CR_CMD_CLOSE_LOCALITY1	0x0388
-#define TXT_CR_CMD_OPEN_LOCALITY2	0x0390
-#define TXT_CR_CMD_CLOSE_LOCALITY2	0x0398
-#define TXT_CR_CMD_SECRETS		0x08e0
-#define TXT_CR_CMD_NO_SECRETS		0x08e8
-#define TXT_CR_E2STS			0x08f0
-
-/* TXT default register value */
-#define TXT_REGVALUE_ONE		0x1ULL
-
-/* TXTCR_STS status bits */
-#define TXT_SENTER_DONE_STS		BIT(0)
-#define TXT_SEXIT_DONE_STS		BIT(1)
-
-/*
- * SINIT/MLE Capabilities Field Bit Definitions
- */
-#define TXT_SINIT_MLE_CAP_WAKE_GETSEC	0
-#define TXT_SINIT_MLE_CAP_WAKE_MONITOR	1
-
-/*
- * OS/MLE Secure Launch Specific Definitions
- */
-#define TXT_OS_MLE_STRUCT_VERSION	1
-#define TXT_OS_MLE_MAX_VARIABLE_MTRRS	32
-
-/*
- * TXT Heap Table Enumeration
- */
-#define TXT_BIOS_DATA_TABLE		1
-#define TXT_OS_MLE_DATA_TABLE		2
-#define TXT_OS_SINIT_DATA_TABLE		3
-#define TXT_SINIT_MLE_DATA_TABLE	4
-#define TXT_SINIT_TABLE_MAX		TXT_SINIT_MLE_DATA_TABLE
 
 /*
  * Secure Launch Defined Error Codes used in MLE-initiated TXT resets.
@@ -150,15 +71,15 @@
 /*
  * Secure Launch Defined Limits
  */
-#define TXT_MAX_CPUS		512
-#define TXT_BOOT_STACK_SIZE	128
+#define SL_MAX_CPUS		512
+#define SL_BOOT_STACK_SIZE	128
 
 /*
  * Secure Launch event log entry type. The TXT specification defines the
  * base event value as 0x400 for DRTM values.
  */
-#define TXT_EVTYPE_BASE			0x400
-#define TXT_EVTYPE_SLAUNCH		(TXT_EVTYPE_BASE + 0x102)
+#define SL_EVTYPE_BASE			0x400
+#define SL_EVTYPE_SECURE_LAUNCH		(SL_EVTYPE_BASE + 0x102)
 
 /*
  * MLE scratch area offsets
@@ -167,7 +88,7 @@
 #define SL_SCRATCH_AP_JMP_OFFSET	4
 #define SL_SCRATCH_AP_STACKS_OFFSET	8
 
-#ifndef __ASSEMBLY__
+#ifndef __ASSEMBLER__
 
 #include <linux/io.h>
 #include <linux/tpm_eventlog.h>
@@ -193,37 +114,6 @@ struct sl_ap_wake_info {
 };
 
 /*
- * TXT heap extended data elements.
- */
-struct txt_heap_ext_data_element {
-	u32 type;
-	u32 size;
-	/* Data */
-} __packed;
-
-#define TXT_HEAP_EXTDATA_TYPE_END			0
-
-struct txt_heap_end_element {
-	u32 type;
-	u32 size;
-} __packed;
-
-#define TXT_HEAP_EXTDATA_TYPE_TPM_EVENT_LOG_PTR		5
-
-struct txt_heap_event_log_element {
-	u64 event_log_phys_addr;
-} __packed;
-
-#define TXT_HEAP_EXTDATA_TYPE_EVENT_LOG_POINTER2_1	8
-
-struct txt_heap_event_log_pointer2_1_element {
-	u64 phys_addr;
-	u32 allocated_event_container_size;
-	u32 first_record_offset;
-	u32 next_record_offset;
-} __packed;
-
-/*
  * Secure Launch defined OS/MLE TXT Heap table
  */
 struct txt_os_mle_data {
@@ -236,214 +126,11 @@ struct txt_os_mle_data {
 	u8 mle_scratch[64];
 } __packed;
 
-/*
- * TXT specification defined BIOS data TXT Heap table
- */
-struct txt_bios_data {
-	u32 version; /* Currently 5 for TPM 1.2 and 6 for TPM 2.0 */
-	u32 bios_sinit_size;
-	u64 reserved1;
-	u64 reserved2;
-	u32 num_logical_procs;
-	/* Versions >= 5 with updates in version 6 */
-	u32 sinit_flags;
-	u32 mle_flags;
-	/* Versions >= 4 */
-	/* Ext Data Elements */
-} __packed;
-
-/*
- * TXT specification defined OS/SINIT TXT Heap table
- */
-struct txt_os_sinit_data {
-	u32 version; /* Currently 6 for TPM 1.2 and 7 for TPM 2.0 */
-	u32 flags;
-	u64 mle_ptab;
-	u64 mle_size;
-	u64 mle_hdr_base;
-	u64 vtd_pmr_lo_base;
-	u64 vtd_pmr_lo_size;
-	u64 vtd_pmr_hi_base;
-	u64 vtd_pmr_hi_size;
-	u64 lcp_po_base;
-	u64 lcp_po_size;
-	u32 capabilities;
-	/* Version = 5 */
-	u64 efi_rsdt_ptr;
-	/* Versions >= 6 */
-	/* Ext Data Elements */
-} __packed;
-
-/*
- * TXT specification defined SINIT/MLE TXT Heap table
- */
-struct txt_sinit_mle_data {
-	u32 version;             /* Current values are 6 through 9 */
-	/* Versions <= 8 */
-	u8 bios_acm_id[20];
-	u32 edx_senter_flags;
-	u64 mseg_valid;
-	u8 sinit_hash[20];
-	u8 mle_hash[20];
-	u8 stm_hash[20];
-	u8 lcp_policy_hash[20];
-	u32 lcp_policy_control;
-	/* Versions >= 7 */
-	u32 rlp_wakeup_addr;
-	u32 reserved;
-	u32 num_of_sinit_mdrs;
-	u32 sinit_mdrs_table_offset;
-	u32 sinit_vtd_dmar_table_size;
-	u32 sinit_vtd_dmar_table_offset;
-	/* Versions >= 8 */
-	u32 processor_scrtm_status;
-	/* Versions >= 9 */
-	/* Ext Data Elements */
-} __packed;
-
-/*
- * TXT data reporting structure for memory types
- */
-struct txt_sinit_memory_descriptor_record {
-	u64 address;
-	u64 length;
-	u8 type;
-	u8 reserved[7];
-} __packed;
-
-/*
- * TXT data structure used by a responsive local processor (RLP) to start
- * execution in response to a GETSEC[WAKEUP].
- */
-struct smx_rlp_mle_join {
-	u32 rlp_gdt_limit;
-	u32 rlp_gdt_base;
-	u32 rlp_seg_sel;     /* cs (ds, es, ss are seg_sel+8) */
-	u32 rlp_entry_point; /* phys addr */
-} __packed;
-
-/*
- * TPM event log structures defined in both the TXT specification and
- * the TCG documentation.
- */
-#define TPM_EVTLOG_SIGNATURE "TXT Event Container"
-
-struct tpm_event_log_header {
-	char signature[20];
-	char reserved[12];
-	u8 container_ver_major;
-	u8 container_ver_minor;
-	u8 pcr_event_ver_major;
-	u8 pcr_event_ver_minor;
-	u32 container_size;
-	u32 pcr_events_offset;
-	u32 next_event_offset;
-	/* PCREvents[] */
-} __packed;
-
-/*
- * Functions to extract data from the Intel TXT Heap Memory. The layout
- * of the heap is as follows:
- *  +----------------------------+
- *  | Size Bios Data table (u64) |
- *  +----------------------------+
- *  | Bios Data table            |
- *  +----------------------------+
- *  | Size OS MLE table (u64)    |
- *  +----------------------------+
- *  | OS MLE table               |
- *  +--------------------------- +
- *  | Size OS SINIT table (u64)  |
- *  +----------------------------+
- *  | OS SINIT table             |
- *  +----------------------------+
- *  | Size SINIT MLE table (u64) |
- *  +----------------------------+
- *  | SINIT MLE table            |
- *  +----------------------------+
- *
- *  NOTE: the table size fields include the 8 byte size field itself.
- */
-static inline u64 txt_bios_data_size(void *heap)
-{
-	return *((u64 *)heap);
-}
-
-static inline void *txt_bios_data_start(void *heap)
-{
-	return heap + sizeof(u64);
-}
-
-static inline u64 txt_os_mle_data_size(void *heap)
-{
-	return *((u64 *)(heap + txt_bios_data_size(heap)));
-}
-
-static inline void *txt_os_mle_data_start(void *heap)
-{
-	return heap + txt_bios_data_size(heap) + sizeof(u64);
-}
-
-static inline u64 txt_os_sinit_data_size(void *heap)
-{
-	return *((u64 *)(heap + txt_bios_data_size(heap) +
-			txt_os_mle_data_size(heap)));
-}
-
-static inline void *txt_os_sinit_data_start(void *heap)
-{
-	return heap + txt_bios_data_size(heap) +
-		txt_os_mle_data_size(heap) + sizeof(u64);
-}
-
-static inline u64 txt_sinit_mle_data_size(void *heap)
-{
-	return *((u64 *)(heap + txt_bios_data_size(heap) +
-			txt_os_mle_data_size(heap) +
-			txt_os_sinit_data_size(heap)));
-}
-
-static inline void *txt_sinit_mle_data_start(void *heap)
-{
-	return heap + txt_bios_data_size(heap) +
-		txt_os_mle_data_size(heap) +
-		txt_os_sinit_data_size(heap) + sizeof(u64);
-}
-
 #if IS_ENABLED(CONFIG_SECURE_LAUNCH)
 
 /*
  * TPM event logging functions.
  */
-
-/*
- * Find the TPM v2 event log element in the TXT heap. This element contains
- * the information about the size and location of the DRTM event log. Note
- * this is a TXT specific structure.
- *
- * See:
- *   Intel Trusted Execution Technology - Measured Launch Environment Developer's Guide - Appendix C.
- */
-static inline struct txt_heap_event_log_pointer2_1_element*
-tpm2_find_log2_1_element(struct txt_os_sinit_data *os_sinit_data)
-{
-	struct txt_heap_ext_data_element *ext_elem;
-
-	/* The extended element array as at the end of this table */
-	ext_elem = (struct txt_heap_ext_data_element *)
-		((u8 *)os_sinit_data + sizeof(struct txt_os_sinit_data));
-
-	while (ext_elem->type != TXT_HEAP_EXTDATA_TYPE_END) {
-		if (ext_elem->type == TXT_HEAP_EXTDATA_TYPE_EVENT_LOG_POINTER2_1) {
-			return (struct txt_heap_event_log_pointer2_1_element *)
-				((u8 *)ext_elem + sizeof(struct txt_heap_ext_data_element));
-		}
-		ext_elem = (struct txt_heap_ext_data_element *)
-			    ((u8 *)ext_elem + ext_elem->size);
-	}
-
-	return NULL;
-}
 
 /*
  * Log a TPM v1 formatted event to the given DRTM event log.
@@ -504,13 +191,12 @@ static inline int tpm2_log_event(struct txt_heap_event_log_pointer2_1_element *e
 /*
  * External functions available in mainline kernel.
  */
-void slaunch_setup_txt(void);
+void slaunch_setup(void);
 void slaunch_fixup_jump_vector(void);
 u32 slaunch_get_flags(void);
 struct sl_ap_wake_info *slaunch_get_ap_wake_info(void);
 struct acpi_table_header *slaunch_get_dmar_table(struct acpi_table_header *dmar);
-void __noreturn slaunch_txt_reset(void __iomem *txt,
-					 const char *msg, u64 error);
+void __noreturn slaunch_reset(void *ctx, const char *msg, u64 error);
 void slaunch_finalize(int do_sexit);
 
 static inline bool slaunch_is_txt_launch(void)
@@ -522,7 +208,7 @@ static inline bool slaunch_is_txt_launch(void)
 
 #else
 
-static inline void slaunch_setup_txt(void)
+static inline void slaunch_setup(void)
 {
 }
 
@@ -551,6 +237,6 @@ static inline bool slaunch_is_txt_launch(void)
 
 #endif /* !IS_ENABLED(CONFIG_SECURE_LAUNCH) */
 
-#endif /* !__ASSEMBLY */
+#endif /* !__ASSEMBLER__ */
 
 #endif /* _LINUX_SLAUNCH_H */


### PR DESCRIPTION
This issue has come up at least twice. The idea is to move the TXT/Intel specific bits into a txt.h header. The slaunch.h header should be arch agnostic as possible.