### PR TITLE
x86/early_tpm_extend: issue COMMAND_READY after successful read

### DIFF
--- a/arch/x86/boot/compressed/early_tpm_extend.c
+++ b/arch/x86/boot/compressed/early_tpm_extend.c
@@ -321,6 +321,7 @@ static int tpm_tis_recv(struct tpm_chip *chip, u8 *buf, int count)
 		goto out;
 	}
 
+	__tis_cancel(chip);
 	return size;
 out:
 	__tis_cancel(chip);


### PR DESCRIPTION
Per "TCG PC Client Specific TPM Interface Specification (TIS), Fig. 3 (State Transition Diagram)" one needs to first issue COMMAND_READY after reading the response, to move from "Command Completion" to "Idle". And then before issuing the next command, another COMMAND_READY is needed to move to "Ready" state.

Some TPM chips do not require it, because specification allows to automatically move from "Idle" to "Ready" and that's why the code worked on some platforms.

Without the fix we get crash in MLE at [1] at second and subsequent call.

[1] https://github.com/TrenchBoot/linux/blob/040f882a9605f39552e70b090ab88716a3cebc66/arch/x86/boot/compressed/sl_main.c#L382