### PR TITLE
x86/slaunch: fix non-reserved SLRT memory access from lateinit

### DIFF
--- a/arch/x86/kernel/slaunch.c
+++ b/arch/x86/kernel/slaunch.c
@@ -24,8 +24,7 @@
 
 static u32 sl_flags __ro_after_init;
 static struct sl_ap_wake_info ap_wake_info __ro_after_init;
-static u64 evtlog_addr __ro_after_init;
-static u32 evtlog_size __ro_after_init;
+static struct slr_entry_log_info sl_log_info __ro_after_init;
 static u64 vtd_pmr_lo_size __ro_after_init;
 
 /* This should be plenty of room */
@@ -47,6 +46,14 @@ u32 slaunch_get_flags(void)
 struct sl_ap_wake_info *slaunch_get_ap_wake_info(void)
 {
 	return &ap_wake_info;
+}
+
+/*
+ * Return the event log information from SLRT.
+ */
+struct slr_entry_log_info  *slaunch_get_log_info(void)
+{
+	return &sl_log_info;
 }
 
 /*
@@ -312,8 +319,8 @@ nomdr:
 	 * event log needs to be reserved. If it is in the TXT heap, it is
 	 * already reserved.
 	 */
-	if (evtlog_addr < heap_base || evtlog_addr > (heap_base + heap_size))
-		slaunch_txt_reserve_range(evtlog_addr, evtlog_size);
+	if (sl_log_info.addr < heap_base || sl_log_info.addr > (heap_base + heap_size))
+		slaunch_txt_reserve_range(sl_log_info.addr, sl_log_info.size);
 
 	for (i = 0; i < e820_table->nr_entries; i++) {
 		base = e820_table->entries[i].addr;
@@ -407,8 +414,7 @@ static void __init slaunch_fetch_values(void __iomem *txt)
 	if (!log_info)
 		slaunch_reset(txt, "SLRT missing logging info entry\n", SL_ERROR_SLRT_MISSING_ENTRY);
 
-	evtlog_addr = log_info->addr;
-	evtlog_size = log_info->size;
+	sl_log_info = *log_info;
 
 	early_memunmap(slrt, size);
 

--- a/arch/x86/kernel/slmodule.c
+++ b/arch/x86/kernel/slmodule.c
@@ -247,7 +247,6 @@ static void slaunch_intel_evtlog(void __iomem *txt)
 {
 	struct slr_entry_log_info *log_info;
 	struct txt_os_mle_data *params;
-	struct slr_table *slrt;
 	void *os_sinit_data;
 	u64 base, size;
 
@@ -261,27 +260,14 @@ static void slaunch_intel_evtlog(void __iomem *txt)
 
 	params = (struct txt_os_mle_data *)txt_os_mle_data_start(txt_heap);
 
-	/* Get the SLRT and remap it */
-	slrt = memremap(params->slrt, sizeof(*slrt), MEMREMAP_WB);
-	if (!slrt)
-		slaunch_reset(txt, "Error failed to memremap SLR Table\n", SL_ERROR_SLRT_MAP);
-	size = slrt->size;
-	memunmap(slrt);
-
-	slrt = memremap(params->slrt, size, MEMREMAP_WB);
-	if (!slrt)
-		slaunch_reset(txt, "Error failed to memremap SLR Table\n", SL_ERROR_SLRT_MAP);
-
-	log_info = slr_next_entry_by_tag(slrt, NULL, SLR_ENTRY_LOG_INFO);
+	log_info = slaunch_get_log_info();
 	if (!log_info)
-		slaunch_reset(txt, "Error failed to memremap SLR Table\n", SL_ERROR_SLRT_MISSING_ENTRY);
+		slaunch_reset(txt, "Error getting TPM event log info\n", SL_ERROR_SLRT_MISSING_ENTRY);
 
 	sl_evtlog.size = log_info->size;
 	sl_evtlog.addr = memremap(log_info->addr, log_info->size, MEMREMAP_WB);
 	if (!sl_evtlog.addr)
 		slaunch_reset(txt, "Error failed to memremap TPM event log\n", SL_ERROR_EVENTLOG_MAP);
-
-	memunmap(slrt);
 
 	/* Determine if this is TPM 1.2 or 2.0 event log */
 	if (memcmp(sl_evtlog.addr + sizeof(struct tcg_pcr_event), TCG_SPECID_SIG, sizeof(TCG_SPECID_SIG)))

--- a/include/linux/slaunch.h
+++ b/include/linux/slaunch.h
@@ -204,6 +204,7 @@ void slaunch_setup(void);
 void slaunch_fixup_ap_wake_vector(void);
 u32 slaunch_get_flags(void);
 struct sl_ap_wake_info *slaunch_get_ap_wake_info(void);
+struct slr_entry_log_info  *slaunch_get_log_info(void);
 struct acpi_table_header *slaunch_get_dmar_table(struct acpi_table_header *dmar);
 void __noreturn slaunch_reset(void *ctx, const char *msg, u64 error);
 void slaunch_finalize(int do_sexit);


### PR DESCRIPTION
SLRT memory region is not memblock_reserved in MLE, yet it was accessed from lateinit. It happened that SLRT was overwritten in the meantime.

The fix makes MLE save the copy of LOG_INFO SLRT entry and then make it accessible to lateinit code via slaunch_get_log_info().